### PR TITLE
Align server identity, add tool titles, and manifest metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ bump-version: ## Set a new version: make bump-version V=0.3.0
 	jq --arg v "$(V)" '.version = $$v' manifest.json > manifest.tmp && mv manifest.tmp manifest.json
 	sed -i.bak 's/^version = ".*"/version = "$(V)"/' pyproject.toml && rm -f pyproject.toml.bak
 	sed -i.bak 's/^version: .*/version: $(V)/' rapid7-bulk-export-skill/SKILL.md && rm -f rapid7-bulk-export-skill/SKILL.md.bak
+	uv lock
 	@echo "Bumped to $(V)"
 
 # ---------------------------------------------------------------------------

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "rapid7-bulk-export",
   "display_name": "Rapid7 Bulk Export",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Export and analyze Rapid7 InsightVM vulnerability data via SQL queries",
   "long_description": "Connects to the Rapid7 Bulk Export API to fetch vulnerability and asset data, loads it into a local DuckDB database, and exposes SQL query tools for AI-powered security analysis. Supports export reuse, EPSS-based prioritization, and cross-cloud vulnerability tracking.",
   "author": {

--- a/manifest.json
+++ b/manifest.json
@@ -85,6 +85,8 @@
     "bulk-export",
     "analysis"
   ],
+  "homepage": "https://github.com/rapid7/rapid7-bulk-export-mcp",
+  "support": "https://github.com/rapid7/rapid7-bulk-export-mcp/issues",
   "license": "MIT",
   "privacy_policies": [
     "https://www.rapid7.com/privacy-policy/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rapid7-vulnerability-export"
-version = "0.2.8"
+version = "0.2.9"
 description = "Python script to export vulnerability data from Rapid7 InsightVM using the Bulk Export API"
 requires-python = ">=3.10"
 dependencies = [

--- a/rapid7-bulk-export-skill/SKILL.md
+++ b/rapid7-bulk-export-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Rapid7 Bulk Export Analysis Expert
 description: Expert analysis of Rapid7 InsightVM data exported via Bulk Export API with strict MCP requirements
-version: 0.2.8
+version: 0.2.9
 author: Rapid7 Bulk Export MCP Tool
 tags: [security, vulnerabilities, rapid7, insightvm, bulk-export, analysis, policy, remediation]
 ---

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -18,7 +18,7 @@ from mcp.types import ToolAnnotations
 from .duckdb_loader import VulnerabilityDatabase
 
 # Initialize FastMCP server
-mcp = FastMCP("rapid7-vulnerability-server")
+mcp = FastMCP("rapid7-bulk-export")
 
 # Global database instance
 db: Optional[VulnerabilityDatabase] = None
@@ -36,6 +36,7 @@ def initialize_database(db_path: str = "rapid7_bulk_export.db") -> Vulnerability
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Load Rapid7 Parquet File",
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=True,
@@ -108,6 +109,7 @@ def load_rapid7_parquet(parquet_path: str) -> str:
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Start Rapid7 Export",
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=True,
@@ -288,6 +290,7 @@ def start_rapid7_export(
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Check Rapid7 Export Status",
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
@@ -349,6 +352,7 @@ def check_rapid7_export_status(export_id: str) -> str:
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Download Rapid7 Export",
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=True,
@@ -492,6 +496,7 @@ def download_rapid7_export(export_id: str, export_type: str = "vulnerability") -
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Query Rapid7 Data",
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
@@ -559,6 +564,7 @@ def query_rapid7(sql: str) -> str:
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Get Rapid7 Schema",
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
@@ -592,6 +598,7 @@ def get_rapid7_schema() -> str:
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Get Rapid7 Statistics",
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
@@ -625,6 +632,7 @@ def get_rapid7_stats() -> str:
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="List Rapid7 Exports",
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,

--- a/uv.lock
+++ b/uv.lock
@@ -1286,7 +1286,7 @@ wheels = [
 
 [[package]]
 name = "rapid7-vulnerability-export"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
Closes https://github.com/rapid7/rapid7-bulk-export-mcp/issues/6

## Changes

**1. Server identity alignment**
- Renamed `FastMCP("rapid7-vulnerability-server")` → `FastMCP("rapid7-bulk-export")` in `src/mcp_server.py` to match the `name` field in `manifest.json`. This ensures the MCP `initialize` handshake returns a consistent `serverInfo.name`.

**2. Tool annotation titles**
- Added a `title` to every `ToolAnnotations(...)` block so Claude Desktop and the MCP Directory can display clean human-readable labels:
  - `Start Rapid7 Export`
  - `Check Rapid7 Export Status`
  - `Download Rapid7 Export`
  - `Load Rapid7 Parquet File`
  - `Query Rapid7 Data`
  - `Get Rapid7 Schema`
  - `Get Rapid7 Statistics`
  - `List Rapid7 Exports`

**3. Manifest metadata**
- Added `homepage` and `support` fields to `manifest.json`.

**4. Version bump → 0.2.9**
- Bumped version across `manifest.json`, `pyproject.toml`, `SKILL.md`, and `uv.lock`.

**5. Makefile improvement**
- `make bump-version` now runs `uv lock` automatically to keep the lock file in sync.

## Testing
- All 71 existing tests pass.
- `make check-version` confirms all version files are in sync.