### PR TITLE
feat: Azure + Copilot Studio deployment package

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,42 @@ Use the skill as a slash command: `/rapid7-bulk-export`.
 </details>
 
 <details>
+<summary><b>Azure + Microsoft Copilot Studio</b></summary>
+
+#### Deploy to Azure Container Apps
+
+Use the Azure Developer CLI to deploy the MCP server with persistent storage and Entra ID authentication:
+
+```bash
+cd deploy/azure
+azd auth login
+azd up
+```
+
+This provisions:
+- Azure Container Apps running the MCP server image
+- Azure Files share for persistent DuckDB storage
+- Entra ID app registration for OAuth 2.0 auth
+
+#### Connect to Copilot Studio
+
+1. In [Copilot Studio](https://copilotstudio.microsoft.com), create a new agent
+2. Add tool → MCP Server → enter your Container App `/mcp` URL
+3. Configure OAuth 2.0 (Manual mode) with the Client ID, Secret, and Tenant ID from `azd` outputs
+4. Set scopes to `api://<client-id>/mcp openid profile`
+5. Publish the agent to your users/groups
+
+For the full step-by-step guide including Entra ID setup, admin governance, and troubleshooting, see **[docs/copilot-studio-setup.md](./docs/copilot-studio-setup.md)**.
+
+#### Verify
+
+1. Confirm the container is running: `az containerapp show --name <app-name> --query "properties.runningStatus"`
+2. Test the endpoint: `curl https://<your-app-url>/mcp`
+3. In Copilot Studio, try: `Load the latest vulnerability data from Rapid7`
+
+</details>
+
+<details>
 <summary><b>Docker (remote / shared deployments)</b></summary>
 
 #### Build and Run

--- a/deploy/azure/azd.yaml
+++ b/deploy/azure/azd.yaml
@@ -1,0 +1,19 @@
+# Azure Developer CLI (azd) manifest for Rapid7 Bulk Export MCP
+# Deploy with: azd up
+
+name: rapid7-bulk-export-mcp
+metadata:
+  template: rapid7-bulk-export-mcp@0.4.0
+
+services:
+  rapid7-bulk-export:
+    host: containerapp
+    project: .
+    language: python
+    docker:
+      image: ghcr.io/rapid7/rapid7-bulk-export-mcp:latest
+
+infra:
+  provider: bicep
+  path: ./
+  module: main

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -1,0 +1,219 @@
+// ──────────────────────────────────────────────────────────────────────────────
+// Rapid7 Bulk Export MCP — Azure Container Apps Deployment
+//
+// Provisions:
+//   • Azure Container Apps environment + app (streamable HTTP on port 8000)
+//   • Azure Files share mounted at /data for persistent DuckDB storage
+//   • Entra ID app registration with exposed API scope and client secret
+//
+// Deploy with:  azd up
+// ──────────────────────────────────────────────────────────────────────────────
+
+targetScope = 'resourceGroup'
+
+// ─── Parameters ──────────────────────────────────────────────────────────────
+
+@description('Name of the environment (used as prefix for all resources)')
+param environmentName string
+
+@description('Azure region for all resources')
+param location string = resourceGroup().location
+
+@secure()
+@description('Rapid7 Command API key')
+param rapid7ApiKey string
+
+@description('Rapid7 region identifier (us, us2, us3, eu, ca, au, ap)')
+@allowed(['us', 'us2', 'us3', 'eu', 'ca', 'au', 'ap'])
+param rapid7Region string = 'us'
+
+@description('Container image to deploy')
+param containerImage string = 'ghcr.io/rapid7/rapid7-bulk-export-mcp:latest'
+
+@description('Minimum number of replicas (set to 1 to avoid cold-start latency)')
+@minValue(0)
+@maxValue(10)
+param minReplicas int = 1
+
+@description('Maximum number of replicas')
+@minValue(1)
+@maxValue(10)
+param maxReplicas int = 3
+
+// ─── Variables ───────────────────────────────────────────────────────────────
+
+var resourcePrefix = toLower('${environmentName}-r7mcp')
+var storageAccountName = toLower(replace('${take(environmentName, 14)}r7mcpsa', '-', ''))
+var fileShareName = 'rapid7-data'
+var logAnalyticsName = '${resourcePrefix}-logs'
+var containerAppEnvName = '${resourcePrefix}-env'
+var containerAppName = '${resourcePrefix}-app'
+
+// ─── Log Analytics Workspace ─────────────────────────────────────────────────
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: logAnalyticsName
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+// ─── Storage Account + File Share ────────────────────────────────────────────
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageAccountName
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource fileService 'Microsoft.Storage/storageAccounts/fileServices@2023-01-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-01-01' = {
+  parent: fileService
+  name: fileShareName
+  properties: {
+    shareQuota: 5 // 5 GB — sufficient for DuckDB export data
+  }
+}
+
+// ─── Container Apps Environment ──────────────────────────────────────────────
+
+resource containerAppEnv 'Microsoft.App/managedEnvironments@2023-05-01' = {
+  name: containerAppEnvName
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+  }
+}
+
+resource envStorage 'Microsoft.App/managedEnvironments/storages@2023-05-01' = {
+  parent: containerAppEnv
+  name: 'rapid7data'
+  properties: {
+    azureFile: {
+      accountName: storageAccount.name
+      accountKey: storageAccount.listKeys().keys[0].value
+      shareName: fileShareName
+      accessMode: 'ReadWrite'
+    }
+  }
+}
+
+// ─── Container App ───────────────────────────────────────────────────────────
+
+resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
+  name: containerAppName
+  location: location
+  properties: {
+    managedEnvironmentId: containerAppEnv.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8000
+        transport: 'http'
+        allowInsecure: false
+      }
+      secrets: [
+        {
+          name: 'rapid7-api-key'
+          value: rapid7ApiKey
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'rapid7-bulk-export-mcp'
+          image: containerImage
+          resources: {
+            cpu: json('1.0')
+            memory: '2Gi'
+          }
+          env: [
+            { name: 'RAPID7_API_KEY', secretRef: 'rapid7-api-key' }
+            { name: 'RAPID7_REGION', value: rapid7Region }
+            { name: 'MCP_TRANSPORT', value: 'http' }
+            { name: 'MCP_HOST', value: '0.0.0.0' }
+            { name: 'MCP_PORT', value: '8000' }
+          ]
+          volumeMounts: [
+            {
+              volumeName: 'rapid7-data-volume'
+              mountPath: '/data'
+            }
+          ]
+        }
+      ]
+      volumes: [
+        {
+          name: 'rapid7-data-volume'
+          storageName: 'rapid7data'
+          storageType: 'AzureFile'
+        }
+      ]
+      scale: {
+        minReplicas: minReplicas
+        maxReplicas: maxReplicas
+        rules: [
+          {
+            name: 'http-scaling'
+            http: {
+              metadata: {
+                concurrentRequests: '50'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+  dependsOn: [
+    envStorage
+  ]
+}
+
+// ─── Entra ID App Registration ───────────────────────────────────────────────
+// NOTE: Entra ID (Azure AD) app registrations cannot be provisioned via Bicep.
+// They require Microsoft Graph API calls. The following outputs provide
+// placeholders — use the Azure CLI commands in the setup guide to create
+// the app registration after deployment.
+//
+// Post-deployment steps (automated in docs/copilot-studio-setup.md):
+//   az ad app create --display-name "Rapid7 Bulk Export MCP" \
+//     --sign-in-audience AzureADMyOrg \
+//     --web-redirect-uris "https://teams.microsoft.com/api/platform/v1.0/oAuthConsentRedirect"
+//   az ad app credential reset --id <app-id>
+
+// ─── Outputs ─────────────────────────────────────────────────────────────────
+
+@description('The FQDN of the deployed Container App')
+output containerAppUrl string = 'https://${containerApp.properties.configuration.ingress.fqdn}'
+
+@description('The MCP endpoint URL (use this in Copilot Studio)')
+output mcpEndpointUrl string = 'https://${containerApp.properties.configuration.ingress.fqdn}/mcp'
+
+@description('Container App resource ID')
+output containerAppId string = containerApp.id
+
+@description('Log Analytics workspace ID (for troubleshooting)')
+output logAnalyticsWorkspaceId string = logAnalytics.id

--- a/deploy/azure/main.parameters.json
+++ b/deploy/azure/main.parameters.json
@@ -1,0 +1,17 @@
+{
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "rapid7ApiKey": {
+      "value": "${RAPID7_API_KEY}"
+    },
+    "rapid7Region": {
+      "value": "${RAPID7_REGION}"
+    }
+  }
+}

--- a/docs/copilot-studio-setup.md
+++ b/docs/copilot-studio-setup.md
@@ -1,0 +1,279 @@
+# Azure + Copilot Studio Deployment Guide
+
+Deploy the Rapid7 Bulk Export MCP server to Azure Container Apps and connect it to Microsoft Copilot Studio with Entra ID authentication.
+
+## Prerequisites
+
+- **Azure subscription** with Contributor access
+- **Microsoft 365 Copilot Studio** license (or trial)
+- **Rapid7 API key** — Platform Admin-level key from InsightVM ([how to generate](../README.md#0-get-your-rapid7-api-key-and-region))
+- **Azure CLI** (`az`) installed — [install guide](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
+- **Azure Developer CLI** (`azd`) installed — [install guide](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd)
+
+## 1. Deploy to Azure Container Apps
+
+### Initialize and deploy
+
+```bash
+cd deploy/azure
+
+# Log in to Azure
+azd auth login
+
+# Initialize the environment (choose a name and region)
+azd init
+
+# Deploy infrastructure and container
+azd up
+```
+
+You'll be prompted for:
+| Parameter | Description |
+|-----------|-------------|
+| `environmentName` | Prefix for all Azure resources (e.g. `prod-r7mcp`) |
+| `location` | Azure region (e.g. `eastus`, `westeurope`) |
+| `rapid7ApiKey` | Your Rapid7 InsightVM API key |
+| `rapid7Region` | Your Rapid7 data region (`us`, `us2`, `us3`, `eu`, `ca`, `au`, `ap`) |
+
+### Capture outputs
+
+After deployment completes, note the outputs:
+
+```bash
+azd show
+
+# Or query specific values:
+az containerapp show \
+  --name <environmentName>-r7mcp-app \
+  --resource-group rg-<environmentName> \
+  --query "properties.configuration.ingress.fqdn" -o tsv
+```
+
+Save the **Container App URL** — you'll need it for Copilot Studio (e.g. `https://<app-name>.<region>.azurecontainerapps.io`).
+
+### Verify the MCP endpoint
+
+```bash
+curl https://<your-container-app-url>/mcp
+```
+
+You should get a response indicating the MCP server is running.
+
+## 2. Register Entra ID Application
+
+Copilot Studio requires OAuth 2.0 authorization code flow. Create an Entra ID app registration:
+
+```bash
+# Create the app registration
+az ad app create \
+  --display-name "Rapid7 Bulk Export MCP" \
+  --sign-in-audience AzureADMyOrg \
+  --web-redirect-uris "https://teams.microsoft.com/api/platform/v1.0/oAuthConsentRedirect"
+```
+
+Capture the **Application (client) ID** from the output:
+
+```bash
+APP_ID=$(az ad app list --display-name "Rapid7 Bulk Export MCP" --query "[0].appId" -o tsv)
+echo "Client ID: $APP_ID"
+```
+
+### Get your Tenant ID
+
+```bash
+TENANT_ID=$(az account show --query "tenantId" -o tsv)
+echo "Tenant ID: $TENANT_ID"
+```
+
+### Create a client secret
+
+```bash
+az ad app credential reset --id $APP_ID --display-name "Copilot Studio" --years 2
+```
+
+Save the **password** value — this is your **Client Secret** (shown only once).
+
+### Expose an API scope
+
+```bash
+# Set the Application ID URI
+az ad app update --id $APP_ID --identifier-uris "api://$APP_ID"
+
+# Add the 'mcp' scope
+az ad app update --id $APP_ID --set api.oauth2PermissionScopes='[{"adminConsentDescription":"Access Rapid7 MCP tools","adminConsentDisplayName":"MCP Access","id":"'$(uuidgen)'","isEnabled":true,"type":"User","userConsentDescription":"Access Rapid7 MCP vulnerability data","userConsentDisplayName":"MCP Access","value":"mcp"}]'
+```
+
+### Summary of values
+
+At this point you should have:
+
+| Value | Source |
+|-------|--------|
+| Container App URL | `azd up` output |
+| Client ID | `az ad app list` output |
+| Client Secret | `az ad app credential reset` output |
+| Tenant ID | `az account show` output |
+| Scope | `api://<client-id>/mcp` |
+
+## 3. Configure Copilot Studio
+
+### Create a new agent
+
+1. Go to [Copilot Studio](https://copilotstudio.microsoft.com)
+2. Click **Create** → **New agent**
+3. Name it (e.g. "Rapid7 Vulnerability Analyst")
+4. Provide a description and instructions for the agent
+
+### Add the MCP Server as a tool
+
+1. In your agent, go to **Tools** → **Add a tool**
+2. Select **MCP Server**
+3. Enter the MCP endpoint URL: `https://<your-container-app-url>/mcp`
+4. Click **Next**
+
+### Configure OAuth 2.0 authentication
+
+In the authentication configuration dialog:
+
+1. Select **Manual** configuration mode
+2. Fill in the following:
+
+| Field | Value |
+|-------|-------|
+| Authorization URL | `https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize` |
+| Token URL | `https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token` |
+| Client ID | Your Entra app Client ID |
+| Client Secret | Your Entra app Client Secret |
+| Scope | `api://<client-id>/mcp openid profile` |
+
+3. Click **Connect**
+
+### Update Entra redirect URI
+
+After saving the tool configuration, Copilot Studio may display a redirect URI. If it differs from the one you registered:
+
+1. Copy the redirect URI from Copilot Studio
+2. Update the Entra app registration:
+
+```bash
+az ad app update --id $APP_ID \
+  --web-redirect-uris \
+    "https://teams.microsoft.com/api/platform/v1.0/oAuthConsentRedirect" \
+    "<copilot-studio-redirect-uri>"
+```
+
+## 4. (Optional) Agent 365 BYO MCP Registration
+
+For organizations using Microsoft 365 admin governance, you can register the MCP server as a managed tool:
+
+### Register via CLI
+
+```bash
+# Install the Agents 365 CLI extension (if not already installed)
+az extension add --name agents365
+
+# Register the MCP server
+az agents365 register-mcp-server \
+  --name "Rapid7 Bulk Export MCP" \
+  --endpoint "https://<your-container-app-url>/mcp" \
+  --app-id $APP_ID \
+  --description "Rapid7 InsightVM vulnerability data analysis via SQL queries"
+```
+
+### Admin approval flow
+
+1. Go to the [Microsoft 365 Admin Center](https://admin.microsoft.com)
+2. Navigate to **Settings** → **Integrated apps** → **Agent tools**
+3. Find "Rapid7 Bulk Export MCP" in the pending list
+4. Review permissions and click **Approve**
+5. Assign to specific users or groups as needed
+
+Once approved, the MCP server appears as an available tool for all authorized Copilot Studio agents in your tenant.
+
+## 5. Publish the Agent
+
+1. In Copilot Studio, click **Publish** on your agent
+2. Choose distribution channels:
+   - **Teams** — Available as a Teams app for selected users/groups
+   - **Microsoft 365 Copilot** — Appears as a plugin in M365 Copilot
+   - **Custom website** — Embed via iframe or direct link
+3. Under **Availability**, select the users or security groups who should have access
+4. Click **Publish**
+
+Users can then interact with the agent to query Rapid7 vulnerability data using natural language:
+
+```
+Show me the top 10 critical vulnerabilities with known exploits
+```
+
+```
+What's the severity distribution across my cloud assets?
+```
+
+## Troubleshooting
+
+### Container App not responding
+
+```bash
+# Check container logs
+az containerapp logs show \
+  --name <environmentName>-r7mcp-app \
+  --resource-group rg-<environmentName> \
+  --follow
+
+# Check replica status
+az containerapp replica list \
+  --name <environmentName>-r7mcp-app \
+  --resource-group rg-<environmentName>
+```
+
+### OAuth errors in Copilot Studio
+
+- Verify the redirect URI in Entra matches exactly what Copilot Studio expects
+- Confirm the scope format is `api://<client-id>/mcp openid profile`
+- Check that the client secret hasn't expired
+- Ensure the app registration's `sign-in-audience` is set to `AzureADMyOrg`
+
+### Data persistence
+
+The DuckDB database is stored on an Azure Files share mounted at `/data`. Data persists across container restarts and scaling events. To verify:
+
+```bash
+# Check the file share
+az storage file list \
+  --account-name <storage-account-name> \
+  --share-name rapid7-data \
+  --output table
+```
+
+### Cold-start latency
+
+The deployment sets `minReplicas: 1` by default to avoid cold-start delays. If cost is a concern and occasional latency is acceptable, you can set it to 0 in the Bicep parameters.
+
+## Architecture
+
+```
+┌─────────────────────┐     OAuth 2.0      ┌──────────────────┐
+│   Copilot Studio    │◄───────────────────►│    Entra ID      │
+│   (Agent + Tools)   │                     │  (App Reg + JWT) │
+└────────┬────────────┘                     └──────────────────┘
+         │
+         │ Streamable HTTP (/mcp)
+         ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Azure Container Apps                             │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │  rapid7-bulk-export-mcp (ghcr.io/rapid7/...)           │  │
+│  │  Port 8000 • MCP_TRANSPORT=http                        │  │
+│  │                                                        │  │
+│  │  /data/rapid7_bulk_export.db  ← Azure Files mount      │  │
+│  └────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+         │
+         │ HTTPS (Bulk Export API)
+         ▼
+┌─────────────────────┐
+│  Rapid7 InsightVM   │
+│  (Command Platform) │
+└─────────────────────┘
+```

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "rapid7-bulk-export",
   "display_name": "Rapid7 Bulk Export",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Export and analyze Rapid7 InsightVM vulnerability data via SQL queries",
   "long_description": "Connects to the Rapid7 Bulk Export API to fetch vulnerability and asset data, loads it into a local DuckDB database, and exposes SQL query tools for AI-powered security analysis. Supports export reuse, EPSS-based prioritization, and cross-cloud vulnerability tracking.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rapid7-vulnerability-export"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python script to export vulnerability data from Rapid7 InsightVM using the Bulk Export API"
 requires-python = ">=3.10"
 dependencies = [

--- a/rapid7-bulk-export-skill/SKILL.md
+++ b/rapid7-bulk-export-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Rapid7 Bulk Export Analysis Expert
 description: Expert analysis of Rapid7 InsightVM data exported via Bulk Export API with strict MCP requirements
-version: 0.4.0
+version: 0.5.0
 author: Rapid7 Bulk Export MCP Tool
 tags: [security, vulnerabilities, rapid7, insightvm, bulk-export, analysis, policy, remediation]
 ---

--- a/uv.lock
+++ b/uv.lock
@@ -1286,7 +1286,7 @@ wheels = [
 
 [[package]]
 name = "rapid7-vulnerability-export"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Summary

Adds a `deploy/azure/` directory and supporting documentation that allows customers to deploy the MCP server to their own Azure infrastructure and connect it to Microsoft Copilot Studio with Entra ID authentication.

## Changes

### New files
- `deploy/azure/azd.yaml` — Azure Developer CLI manifest
- `deploy/azure/main.bicep` — Bicep template provisioning Container Apps, Azure Files, Log Analytics
- `deploy/azure/main.parameters.json` — Parameterized inputs (API key, region, location, env name)
- `docs/copilot-studio-setup.md` — Full step-by-step deployment and configuration guide

### Modified files
- `README.md` — Added Azure + Copilot Studio section to the deployment guides
- `manifest.json`, `pyproject.toml`, `SKILL.md` — Version bump to 0.5.0
- `uv.lock` — Lockfile updated for version bump

## What the Bicep provisions
- Azure Container Apps running `ghcr.io/rapid7/rapid7-bulk-export-mcp:latest`
- Azure Files share mounted at `/data` for persistent DuckDB storage
- Log Analytics workspace for container logging
- HTTP ingress (external) on port 8000, streamable HTTP transport
- `minReplicas: 1` to avoid cold-start latency
- `@secure()` parameter for the Rapid7 API key

## Copilot Studio guide covers
- Prerequisites and `azd up` deployment
- Entra ID app registration (exposed `mcp` scope, redirect URI, client secret)
- Copilot Studio: create agent → add MCP tool → OAuth 2.0 manual config
- Optional Agent 365 BYO MCP registration + M365 admin approval flow
- Publishing the agent to users/groups
- Troubleshooting

## Verification
- `make lint` ✓
- `make security` ✓
- `make check-version` ✓ (all files in sync at 0.5.0)