### PR TITLE
feat: macOS Keychain fallback for API key

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "rapid7-bulk-export",
   "display_name": "Rapid7 Bulk Export",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Export and analyze Rapid7 InsightVM vulnerability data via SQL queries",
   "long_description": "Connects to the Rapid7 Bulk Export API to fetch vulnerability and asset data, loads it into a local DuckDB database, and exposes SQL query tools for AI-powered security analysis. Supports export reuse, EPSS-based prioritization, and cross-cloud vulnerability tracking.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rapid7-vulnerability-export"
-version = "0.5.1"
+version = "0.5.2"
 description = "Python script to export vulnerability data from Rapid7 InsightVM using the Bulk Export API"
 requires-python = ">=3.10"
 dependencies = [

--- a/rapid7-bulk-export-skill/SKILL.md
+++ b/rapid7-bulk-export-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Rapid7 Bulk Export Analysis Expert
 description: Expert analysis of Rapid7 InsightVM data exported via Bulk Export API with strict MCP requirements
-version: 0.5.1
+version: 0.5.2
 author: Rapid7 Bulk Export MCP Tool
 tags: [security, vulnerabilities, rapid7, insightvm, bulk-export, analysis, policy, remediation]
 ---

--- a/src/config.py
+++ b/src/config.py
@@ -4,7 +4,9 @@ This module handles loading and validating configuration from environment variab
 """
 
 import os
-from typing import Dict
+import platform
+import subprocess  # nosec B404
+from typing import Dict, Optional
 
 USER_AGENT = "r7:bulk-export-mcp"
 
@@ -21,11 +23,45 @@ REGION_ENDPOINTS = {
 }
 
 
+def _get_key_from_keychain(service_name: str) -> Optional[str]:
+    """Retrieve a password from macOS Keychain.
+
+    Uses the `security find-generic-password` command to look up a stored
+    credential by service name. Only available on macOS.
+
+    Args:
+        service_name: The service name used when storing the credential.
+
+    Returns:
+        The password string if found, None otherwise.
+    """
+    if platform.system() != "Darwin":
+        return None
+
+    try:
+        result = subprocess.run(  # nosec B603 B607
+            ["security", "find-generic-password", "-s", service_name, "-w"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+        value = result.stdout.strip()
+        return value if value else None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
 def load_config() -> Dict[str, str]:
     """Load and validate configuration from environment variables.
 
     Reads the RAPID7_API_KEY and RAPID7_REGION environment variables,
     validates them, and constructs the appropriate API endpoint URL.
+
+    On macOS, if RAPID7_API_KEY is not found in the environment, falls back
+    to reading from the macOS Keychain. Store credentials with:
+
+        security add-generic-password -s RAPID7_API_KEY -a rapid7 -w <your-key>
 
     Returns:
         dict: Configuration dictionary containing:
@@ -40,8 +76,17 @@ def load_config() -> Dict[str, str]:
     """
     # Read API key from environment
     api_key = os.environ.get("RAPID7_API_KEY")
+
+    # Fall back to macOS Keychain if not in environment
     if not api_key:
-        raise ValueError("RAPID7_API_KEY environment variable is not set")
+        api_key = _get_key_from_keychain("RAPID7_API_KEY")
+
+    if not api_key:
+        raise ValueError(
+            "RAPID7_API_KEY not found. Set the environment variable or, on macOS, "
+            "store it in Keychain: "
+            "security add-generic-password -s RAPID7_API_KEY -a rapid7 -w <your-key>"
+        )
 
     # Read region from environment (default to 'us')
     region = os.environ.get("RAPID7_REGION", "us")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,11 @@
 """Unit tests for the configuration module."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.config import REGION_ENDPOINTS, load_config
+from src.config import REGION_ENDPOINTS, _get_key_from_keychain, load_config
 
 
 class TestLoadConfig:
@@ -32,7 +32,7 @@ class TestLoadConfig:
     def test_missing_api_key_raises_error(self):
         """Test that missing RAPID7_API_KEY raises ValueError."""
         with patch.dict(os.environ, {"RAPID7_REGION": "us"}, clear=True):
-            with pytest.raises(ValueError, match="RAPID7_API_KEY environment variable is not set"):
+            with pytest.raises(ValueError, match="RAPID7_API_KEY not found"):
                 load_config()
 
     def test_missing_region_defaults_to_us(self):
@@ -57,7 +57,7 @@ class TestLoadConfig:
     def test_empty_api_key_raises_error(self):
         """Test that empty RAPID7_API_KEY raises ValueError."""
         with patch.dict(os.environ, {"RAPID7_API_KEY": "", "RAPID7_REGION": "us"}):
-            with pytest.raises(ValueError, match="RAPID7_API_KEY environment variable is not set"):
+            with pytest.raises(ValueError, match="RAPID7_API_KEY not found"):
                 load_config()
 
     def test_empty_region_raises_invalid_region_error(self):
@@ -75,3 +75,46 @@ class TestLoadConfig:
             assert "region" in config
             assert "endpoint" in config
             assert len(config) == 3  # Ensure no extra keys
+
+
+class TestKeychainFallback:
+    """Tests for macOS Keychain credential fallback."""
+
+    @patch("src.config.platform.system", return_value="Darwin")
+    @patch("src.config.subprocess.run")
+    def test_keychain_fallback_when_env_not_set(self, mock_run, mock_system):
+        """Test that Keychain is used when env var is missing."""
+        mock_run.return_value = MagicMock(stdout="keychain-api-key-123\n", returncode=0)
+
+        with patch.dict(os.environ, {"RAPID7_REGION": "us"}, clear=True):
+            config = load_config()
+
+        assert config["api_key"] == "keychain-api-key-123"
+        mock_run.assert_called_once()
+
+    @patch("src.config.platform.system", return_value="Darwin")
+    @patch("src.config.subprocess.run")
+    def test_env_var_takes_precedence_over_keychain(self, mock_run, mock_system):
+        """Test that environment variable is preferred over Keychain."""
+        with patch.dict(os.environ, {"RAPID7_API_KEY": "env-key", "RAPID7_REGION": "us"}):
+            config = load_config()
+
+        assert config["api_key"] == "env-key"
+        mock_run.assert_not_called()
+
+    @patch("src.config.platform.system", return_value="Linux")
+    def test_keychain_skipped_on_non_macos(self, mock_system):
+        """Test that Keychain lookup is skipped on non-macOS systems."""
+        result = _get_key_from_keychain("RAPID7_API_KEY")
+        assert result is None
+
+    @patch("src.config.platform.system", return_value="Darwin")
+    @patch("src.config.subprocess.run")
+    def test_keychain_returns_none_on_failure(self, mock_run, mock_system):
+        """Test that Keychain failure returns None gracefully."""
+        import subprocess
+
+        mock_run.side_effect = subprocess.CalledProcessError(44, "security")
+
+        result = _get_key_from_keychain("RAPID7_API_KEY")
+        assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -1331,7 +1331,7 @@ wheels = [
 
 [[package]]
 name = "rapid7-vulnerability-export"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

Adds macOS Keychain as a fallback credential source when `RAPID7_API_KEY` is not set as an environment variable. This avoids storing API keys in plain-text MCP configuration files.

## Behavior

- **Environment variable takes precedence** — existing behavior is unchanged
- **If env var is missing**, attempts macOS Keychain lookup via `security find-generic-password`
- **On non-macOS systems**, Keychain lookup is silently skipped (no error)
- **On failure** (key not found, timeout, etc.), returns a clear error message guiding the user

## Usage

Store the key once:
```bash
security add-generic-password -s RAPID7_API_KEY -a rapid7 -w <your-api-key>
```

Then remove `RAPID7_API_KEY` from your `mcp.json` env block — the server will read it from Keychain at startup.

## Testing

- 4 new unit tests covering: fallback behavior, env precedence, non-macOS skip, failure handling
- All 13 config tests pass
- No changes to existing behavior when env var is set