### PR TITLE
Cortex: move domain parent to surface-command-platform

### DIFF
--- a/cortex.yaml
+++ b/cortex.yaml
@@ -9,7 +9,7 @@ info:
   x-cortex-tag: rapid7-bulk-export-mcp
   x-cortex-type: service
   x-cortex-domain-parents:
-    - tag: surface-command
+    - tag: surface-command-platform
   x-cortex-groups:
     - target:not-deployed
     - strategy:cloud


### PR DESCRIPTION
Repoints this service's Cortex domain from `surface-command` to the new `surface-command-platform` leaf domain.

Part of the Surface Command team-ownership split: three registered Cortex teams
(`rapid7-surface-command-engineering`, `rapid7-surface-command-easm`, `rapid7-surface-command-connectors`)
must each own a disjoint set of services. `surface-command` held services directly, so there was nowhere
to attach the engineering team without also attaching it to everything under `surface-command-easm`.

The new leaf domains landed in rapid7/pd-cortex-gitops#233. Each carries exactly one team as an
`APPEND` owner, so no per-service `x-cortex-owners` is needed here — ownership comes from the domain.
Any existing service-level owner on this repo is preserved.

The shared `surface-command` parent deliberately carries no team tag, which is what keeps the three
teams' service sets disjoint. Its umbrella owners (`rapid7/rapid7-surface`, `jit-approvers-surface`)
still reach this service, unchanged.

Snyk coverage is unaffected: `cortex_domains = ["surface-command"]` in
`tf-cortex-snyk-sync-configurations` covers child domains.