### PR TITLE
[PLEX-5770] Bound DuckDB memory and threads to prevent OOM on large loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,8 @@ uv run pytest
 | `RAPID7_API_KEY` | Yes | — | Rapid7 InsightVM API key |
 | `RAPID7_REGION` | Yes | `us` | API region: `us`, `us2`, `us3`, `eu`, `ca`, `au`, `ap` |
 | `DATA_DIR` | No | `~/.rapid7_mcp` | Directory for database files; must be writable. Manual parquet imports must be placed in `$DATA_DIR/imports/` |
+| `DUCKDB_MEMORY_LIMIT` | No | `4GB` | Size of DuckDB's buffer pool, e.g. `4GB`, `512MB`. This bounds the buffer pool, **not** total process memory: peak usage runs roughly 1.8x this value with `DUCKDB_THREADS=2` and up to 3.4x at the default thread count. Size it to about a third of the memory available to the container. Invalid values fall back to the default. Spill files are written to `$DATA_DIR` alongside the database |
+| `DUCKDB_THREADS` | No | CPU count | Worker threads DuckDB may use. Each carries its own buffers, so lowering this is the most effective way to cut peak memory on a large load. `2` roughly halves peak memory for about 30% more load time. Values that are not a positive integer are ignored |
 | `MCP_TRANSPORT` | No | `stdio` | Transport protocol: `stdio` or `http` |
 | `MCP_HOST` | No | `0.0.0.0` | HTTP bind address (only when `MCP_TRANSPORT=http`) |
 | `MCP_PORT` | No | `8000` | HTTP port (only when `MCP_TRANSPORT=http`) |

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "rapid7-bulk-export",
   "display_name": "Rapid7 Bulk Export",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Export and analyze Rapid7 InsightVM vulnerability data via SQL queries",
   "long_description": "Connects to the Rapid7 Bulk Export API to fetch vulnerability and asset data, loads it into a local DuckDB database, and exposes SQL query tools for AI-powered security analysis. Supports export reuse, EPSS-based prioritization, and cross-cloud vulnerability tracking.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rapid7-vulnerability-export"
-version = "0.5.3"
+version = "0.5.4"
 description = "Python script to export vulnerability data from Rapid7 InsightVM using the Bulk Export API"
 requires-python = ">=3.10"
 dependencies = [

--- a/rapid7-bulk-export-skill/SKILL.md
+++ b/rapid7-bulk-export-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Rapid7 Bulk Export Analysis Expert
 description: Expert analysis of Rapid7 InsightVM data exported via Bulk Export API with strict MCP requirements
-version: 0.5.3
+version: 0.5.4
 author: Rapid7 Bulk Export MCP Tool
 tags: [security, vulnerabilities, rapid7, insightvm, bulk-export, analysis, policy, remediation]
 ---

--- a/src/db_utils.py
+++ b/src/db_utils.py
@@ -1,10 +1,51 @@
 """Shared DuckDB connection utilities for short-lived, concurrent-safe access."""
 
+import os
+import re
+import sys
 import time
 from contextlib import contextmanager
 from typing import Generator
 
 import duckdb
+
+DEFAULT_MEMORY_LIMIT = "4GB"
+
+_MEMORY_LIMIT_PATTERN = re.compile(r"^\d+(\.\d+)?\s*(K|M|G|T)?i?B$", re.IGNORECASE)
+
+
+def _resolve_memory_limit() -> str:
+    """Return the configured DuckDB memory limit, or the default if unset or unparseable."""
+    configured = os.environ.get("DUCKDB_MEMORY_LIMIT", "").strip()
+    if not configured:
+        return DEFAULT_MEMORY_LIMIT
+    if not _MEMORY_LIMIT_PATTERN.match(configured):
+        print(
+            f"Warning: ignoring invalid DUCKDB_MEMORY_LIMIT '{configured}', using {DEFAULT_MEMORY_LIMIT}",
+            file=sys.stderr,
+        )
+        return DEFAULT_MEMORY_LIMIT
+    return configured
+
+
+def _apply_resource_limits(conn: duckdb.DuckDBPyConnection, db_path: str) -> None:
+    """Bound the buffer pool and give DuckDB an on-disk location to spill to.
+
+    Left unset, DuckDB sizes its buffer pool at roughly 75% of the memory it can
+    see, which is the container limit when one is set and host memory otherwise.
+    That is too high to survive a large load, because memory_limit bounds the
+    buffer pool rather than process RSS: measured peak RSS runs about 1.8x the
+    limit with two threads and about 3.4x with ten, since each worker carries its
+    own buffers. Capping threads is therefore as load-bearing as the limit
+    itself. The temp directory sits alongside the database file so spill lands on
+    the same writable volume.
+    """
+    conn.execute(f"SET memory_limit = '{_resolve_memory_limit()}'")  # nosec B608
+    threads = os.environ.get("DUCKDB_THREADS", "").strip()
+    if threads.isdigit() and int(threads) > 0:
+        conn.execute(f"SET threads = {int(threads)}")  # nosec B608
+    temp_directory = f"{db_path}.tmp".replace("'", "''")
+    conn.execute(f"SET temp_directory = '{temp_directory}'")  # nosec B608
 
 
 def connect_with_retry(db_path: str, read_only: bool = False, max_retries: int = 5) -> duckdb.DuckDBPyConnection:
@@ -38,9 +79,10 @@ def duckdb_connection(
 ) -> Generator[duckdb.DuckDBPyConnection, None, None]:
     """Context manager for a short-lived DuckDB connection.
 
-    Opens the connection, optionally disables external filesystem access,
-    yields it, then closes it on exit. Uses connect_with_retry to handle
-    transient write-lock contention from concurrent processes.
+    Opens the connection, applies the memory limit and spill directory,
+    optionally disables external filesystem access, yields it, then closes it on
+    exit. Uses connect_with_retry to handle transient write-lock contention from
+    concurrent processes.
 
     Args:
         db_path: Path to the DuckDB database file.
@@ -50,6 +92,9 @@ def duckdb_connection(
     """
     conn = connect_with_retry(db_path, read_only=read_only)
     try:
+        # Must precede disable_external_access: once external access is off,
+        # DuckDB rejects changes to temp_directory.
+        _apply_resource_limits(conn, db_path)
         if disable_external_access:
             conn.execute("SET enable_external_access = false")
         yield conn

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,0 +1,99 @@
+"""Tests for DuckDB connection resource limits."""
+
+import pytest
+
+from src.db_utils import DEFAULT_MEMORY_LIMIT, _resolve_memory_limit, duckdb_connection
+
+
+def _current_setting(conn, name):
+    return conn.execute(f"SELECT current_setting('{name}')").fetchone()[0]
+
+
+@pytest.mark.parametrize(
+    "configured,expected",
+    [
+        (None, DEFAULT_MEMORY_LIMIT),
+        ("", DEFAULT_MEMORY_LIMIT),
+        ("4GB", "4GB"),
+        ("1.5GiB", "1.5GiB"),
+        ("2 GB", "2 GB"),
+        ("not-a-size", DEFAULT_MEMORY_LIMIT),
+        ("8", DEFAULT_MEMORY_LIMIT),
+        ("8GB; DROP TABLE assets", DEFAULT_MEMORY_LIMIT),
+    ],
+)
+def test_resolve_memory_limit(monkeypatch, configured, expected):
+    if configured is None:
+        monkeypatch.delenv("DUCKDB_MEMORY_LIMIT", raising=False)
+    else:
+        monkeypatch.setenv("DUCKDB_MEMORY_LIMIT", configured)
+
+    assert _resolve_memory_limit() == expected
+
+
+def test_invalid_limit_warns_and_falls_back(monkeypatch, capsys):
+    monkeypatch.setenv("DUCKDB_MEMORY_LIMIT", "plenty")
+
+    assert _resolve_memory_limit() == DEFAULT_MEMORY_LIMIT
+    assert "ignoring invalid DUCKDB_MEMORY_LIMIT" in capsys.readouterr().err
+
+
+def test_connection_applies_memory_limit(tmp_path, monkeypatch):
+    monkeypatch.setenv("DUCKDB_MEMORY_LIMIT", "1GiB")
+    db_path = str(tmp_path / "test.db")
+
+    with duckdb_connection(db_path) as conn:
+        assert _current_setting(conn, "memory_limit") == "1.0 GiB"
+
+
+def test_connection_applies_temp_directory(tmp_path):
+    db_path = str(tmp_path / "test.db")
+
+    with duckdb_connection(db_path) as conn:
+        assert _current_setting(conn, "temp_directory") == f"{db_path}.tmp"
+
+
+def test_limits_applied_to_read_only_connection(tmp_path, monkeypatch):
+    monkeypatch.setenv("DUCKDB_MEMORY_LIMIT", "2GiB")
+    db_path = str(tmp_path / "test.db")
+
+    with duckdb_connection(db_path) as conn:
+        conn.execute("CREATE TABLE t AS SELECT 1 AS x")
+
+    with duckdb_connection(db_path, read_only=True) as conn:
+        assert _current_setting(conn, "memory_limit") == "2.0 GiB"
+        assert _current_setting(conn, "temp_directory") == f"{db_path}.tmp"
+
+
+@pytest.mark.parametrize("configured,expected", [("2", 2), ("1", 1)])
+def test_threads_override_applied(tmp_path, monkeypatch, configured, expected):
+    monkeypatch.setenv("DUCKDB_THREADS", configured)
+    db_path = str(tmp_path / "test.db")
+
+    with duckdb_connection(db_path) as conn:
+        assert _current_setting(conn, "threads") == expected
+
+
+@pytest.mark.parametrize("configured", ["", "0", "-1", "many", "2; DROP TABLE assets"])
+def test_invalid_threads_leaves_duckdb_default(tmp_path, monkeypatch, configured):
+    db_path = str(tmp_path / "test.db")
+
+    with duckdb_connection(db_path) as conn:
+        default = _current_setting(conn, "threads")
+
+    monkeypatch.setenv("DUCKDB_THREADS", configured)
+    with duckdb_connection(db_path) as conn:
+        assert _current_setting(conn, "threads") == default
+
+
+def test_limits_applied_before_external_access_disabled(tmp_path, monkeypatch):
+    """disable_external_access must not block the temp_directory setting."""
+    monkeypatch.setenv("DUCKDB_MEMORY_LIMIT", "3GiB")
+    db_path = str(tmp_path / "test.db")
+
+    with duckdb_connection(db_path) as conn:
+        conn.execute("CREATE TABLE t AS SELECT 1 AS x")
+
+    with duckdb_connection(db_path, read_only=True, disable_external_access=True) as conn:
+        assert _current_setting(conn, "memory_limit") == "3.0 GiB"
+        assert _current_setting(conn, "temp_directory") == f"{db_path}.tmp"

--- a/uv.lock
+++ b/uv.lock
@@ -1331,7 +1331,7 @@ wheels = [
 
 [[package]]
 name = "rapid7-vulnerability-export"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -1620,8 +1620,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Problem

Loading a large policy export kills the container. v0.5.3, Docker, EC2 m6i.2xlarge (32 GiB). All 22 parquet files downloaded and the export reported COMPLETE, then the container exited 137 during the load, peaking at 27.95 GiB of 30.81 GiB.

`src/db_utils.py` never set `memory_limit` or `temp_directory`. DuckDB sizes its buffer pool at roughly 75% of the memory it can see, which is the cgroup limit when one is set and host memory otherwise. Ciena run without `-m`, so DuckDB was free to take ~25 GiB of their 32 GiB host and climbed until the kernel killed the process.

## Change

Three session settings applied in `duckdb_connection`, before `enable_external_access` is disabled (DuckDB rejects `temp_directory` changes once external access is off, and there is a test pinning that ordering):

- `memory_limit`, from `DUCKDB_MEMORY_LIMIT`, default `4GB`
- `threads`, from `DUCKDB_THREADS`, default left to DuckDB
- `temp_directory`, alongside the database file on the `DATA_DIR` volume

Both env values are validated. Anything unparseable falls back to the default with a warning on stderr rather than failing to open a connection.

## Verification

Reproduced and fixed in a Linux container (cgroup v2). Synthetic dataset matching the real 15-column policy schema including the two `LIST(VARCHAR)` columns, 2.8M rows across 22 files, identical data and code path for every run.

| Run | Container | `DUCKDB_MEMORY_LIMIT` | `DUCKDB_THREADS` | Outcome | Peak RSS |
|---|---|---|---|---|---|
| A | no limit | unset (pre-fix) | default (10) | **exit 137, OOMKilled** | — |
| C | `-m 4g` | unset (pre-fix) | default (10) | **exit 137, OOMKilled** | — |
| B | no limit | `1GiB` | default (10) | exit 0, 2,799,984 rows | 3.37 GiB |
| D | no limit | `1GiB` | `2` | exit 0, 2,799,984 rows | 1.81 GiB |

Three things this established:

1. **DuckDB is cgroup-aware.** In a 2 GiB container it defaulted `memory_limit` to 1.5 GiB rather than reading host memory. Confirmed on two independent glibc base images.
2. **Capping the container alone does not fix it (run C).** `memory_limit` bounds the buffer pool, not process RSS, and measured overshoot was 3.4x at the default thread count.
3. **Threads is as load-bearing as the limit (run D).** Dropping to 2 cut peak RSS from 3.37 to 1.81 GiB, overshoot 3.4x to 1.8x, for about 30% more load time. This is why the change includes a threads knob and why the default limit is 4GB rather than 8GB.

The v0.5.3 `_compact()` step was also measured as the dominant consumer when the pool is unbounded: it added 4.5 GiB of peak RSS to an 8.7 GiB load, 2.06 to 6.59 GiB. Under a 1 GiB limit that collapses to +0.10 GiB, so this change neutralises it without touching the compaction code.

Query-side cost of bounding, 4.15M rows, identical queries:

| Query | Unbounded | 512MiB (7x overcommit) |
|---|---|---|
| `GROUP BY` high cardinality | 0.1s / 0.38 GiB | 0.1s / 0.40 GiB |
| `ORDER BY` wide text | 1.9s / 2.96 GiB | 1.5s / 0.70 GiB |
| `DISTINCT` on wide columns | 5.7s / 3.57 GiB | 8.6s / 0.90 GiB |

Worst case about 50% slower on the heaviest aggregation for 4x less memory. At the 4GB default on that dataset the difference was inside noise. Nothing failed.

`109 passed, 1 skipped`. `ruff check` and `ruff format --check` clean.

## Limitations

- Synthetic rows are 2 to 3 KB. Ciena's must be fatter to reach 28 GiB, so this is a scaled proof of the mechanism, not a reproduction of their exact load. Confirmation against real policy data is still needed.
- `temp_directory` was never exercised: the load streams rather than spills. It is insurance for query-time spilling.
- A fixed 4GB default cannot suit every deployment. At up to 3.4x overshoot it implies ~13.6 GiB peak, which protects a 32 GiB host but not a small container. Deriving it from `memory.max` would be better and is stage 4 on PLEX-5770.

## Not in scope

Three other consumers remain, all of which sit outside DuckDB and are unaffected by `memory_limit`:

1. `download_all_files` returns `List[bytes]` and `download_parquet_file` returns `response.content`, so all files are buffered whole in RAM, still referenced at `mcp_server.py:458`.
2. Those bytes are written to `tempfile.mkdtemp()` under `TMPDIR=/tmp`, which both documented deployments mount as tmpfs, so they occupy RAM a second time.
3. `_compact()` still copies the whole database on every snapshot load and roughly doubles load wall time (44 to 94s, 49 to 93s at every limit tested).

This is a floor, not a complete fix. Items 1 and 2 are stage 2 on PLEX-5770, item 3 is stage 3, and deriving the limit from the cgroup is stage 4. This PR is stage 1.

## Customer guidance until this ships

Patched image with `DUCKDB_MEMORY_LIMIT=4GB` and `DUCKDB_THREADS=2`, and `/tmp` on a disk-backed volume rather than tmpfs (compatible with `--read-only`). Do not rely on `-m` alone; run C shows it does not help.

## Rollback

Revert the commit. Three session-level `SET` statements, no data migration or state to unwind.

https://rapid7.atlassian.net/browse/PLEX-5770
