### PR TITLE
fix: multi-window remediation loads + unified background-load status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,9 +101,22 @@ Each step is non-blocking. The tracking DB (`rapid7_bulk_export_tracking.db`) re
 - `download_rapid7_export` handles this automatically based on `export_type`
 
 **Remediation exports**
-- API limit: 31 days per request — larger ranges are chunked automatically
-- Today-reuse logic is skipped for remediation (date-range scoped, not a snapshot)
-- All chunks load into a single `vulnerability_remediation` table via append mode
+- The platform allows only ONE export per type in flight at a time. Remediation
+  is date-range scoped, so concurrent windows cannot be created — they must be
+  produced strictly one at a time.
+- API limit: 31 days per request. A larger range is split into ≤31-day windows.
+- `start_rapid7_export(export_type="remediation", start_date, end_date)` hands the
+  whole range to a single background job that, per window, sequentially:
+  create → poll to COMPLETE → download → load (`append=True`). It returns a
+  `job_id` immediately; poll it with `check_rapid7_export_status(export_id=job_id)`.
+- If the platform reports another remediation export already in flight, the job
+  waits and recreates its OWN window rather than adopting the foreign export id
+  (that id may cover a different date range).
+- Today-reuse logic is skipped for remediation (date-range scoped, not a snapshot).
+- All windows append into a single `vulnerability_remediation` table.
+- Partial failure is explicit: if a window fails, the loaded windows are kept and
+  the job message names exactly which windows loaded and which are missing, so the
+  missing range can be re-run.
 
 **best_solution fields**
 - `bestSolutionType`, `bestSolutionSummary`, `bestSolutionFix` appear in the `vulnerabilities` table if the org is enabled
@@ -134,9 +147,9 @@ The actual tool names exposed by the server (use these exactly in tool calls):
 
 | Tool | Purpose |
 |---|---|
-| `start_rapid7_export` | Create an export job — returns an export ID immediately |
-| `check_rapid7_export_status` | Poll status of an export job once (non-blocking) |
-| `download_rapid7_export` | Download a completed export and load into DuckDB |
+| `start_rapid7_export` | Create an export job — returns an export ID (or a job ID for a multi-window remediation range) immediately |
+| `check_rapid7_export_status` | Poll status once (non-blocking): platform export status, local download/load phase, or multi-window job progress — accepts an export ID or a job ID |
+| `download_rapid7_export` | Start downloading a completed export and loading it into DuckDB in the background |
 | `load_rapid7_parquet` | Load existing Parquet files from `$DATA_DIR/imports/` |
 | `query_rapid7` | Execute SQL against loaded tables |
 | `get_rapid7_schema` | Return column names and types for all loaded tables |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## 0.6.0
+
+### Fixed
+
+- **Multi-month remediation exports now load every window.** Previously, requesting
+  remediation data for a range longer than one month could silently load only a
+  single 31-day window. The Rapid7 platform allows only one remediation export in
+  flight at a time and splits a longer range into multiple exports; the tool created
+  them without sequencing, so all windows collapsed onto one export ID and only one
+  month's data was downloaded — and it could be any month in the requested range.
+
+  **Impact:** if you ran a remediation export covering more than 31 days on an earlier
+  version, it may have loaded only part of your range. Re-run that export on 0.6.0 to
+  get the complete data.
+
+### Changed
+
+- Requesting a remediation range now starts a single background job that creates,
+  downloads, and loads each ≤31-day window in order and appends them into one
+  `vulnerability_remediation` table. `start_rapid7_export(export_type="remediation", …)`
+  returns a job ID; poll it with `check_rapid7_export_status`. Partial failures are
+  explicit — the job reports exactly which windows loaded and which are missing so the
+  missing range can be re-run.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This tool exports data from Rapid7 Command Platform, via the [Rapid7 Bulk Export
 - **Export Reuse**: Automatically reuses exports from the same day to avoid redundant API calls
 - **Natural Language Queries**: Ask questions in plain English
 - **SQL Query Execution**: Run complex SQL queries against vulnerability, asset and other data
+- **Multiple Export Types**: Vulnerabilities (with vulnerability exceptions), policies, remediations, and installed asset software
+- **Multi-Month Remediation**: Request any date range — it is split into ≤31-day windows and loaded for you in the background as a single job
 - **Schema Exploration**: Discover available data fields
 - **Statistics & Insights**: Get instant summaries and distributions
 - **Security Lockdown**: User queries are sandboxed — filesystem and network access disabled at the DuckDB engine level
@@ -465,15 +467,18 @@ What's the severity distribution across my cloud assets?
 
 ### `start_rapid7_export`
 
-Kicks off a new export job on Rapid7's servers. Returns immediately with an export ID. Supports three export types: `vulnerability`, `policy`, and `remediation`.
+Kicks off a new export job on Rapid7's servers. Returns immediately. Supports four export types: `vulnerability`, `policy`, `remediation`, and `asset_software`.
+
+For `remediation`, pass a `start_date` and `end_date` (YYYY-MM-DD). Rapid7 limits each remediation export to 31 days and allows only one in flight at a time, so a longer range is split into ≤31-day windows and processed sequentially in the background as a single job. The call returns a **job ID** you poll with `check_rapid7_export_status`; all windows append into one `vulnerability_remediation` table.
 
 ```
 Start a vulnerability export from Rapid7
+Load remediation data from 2026-01-01 to 2026-06-30
 ```
 
 ### `check_rapid7_export_status`
 
-Polls the Rapid7 API once for the current status of an export job. Use after `start_rapid7_export` to know when data is ready.
+Reports status once, without blocking. Depending on what the ID names, it returns the Rapid7 platform-side export status, the local download/load progress once you have started loading, or the progress of a multi-window remediation job (which window is loading, and which windows are done). Accepts either an export ID or a remediation job ID.
 
 ```
 Check the status of export abc-123
@@ -481,7 +486,7 @@ Check the status of export abc-123
 
 ### `download_rapid7_export`
 
-Downloads a completed export's Parquet files and loads them into the local DuckDB database. This is where data becomes queryable.
+Starts downloading a completed export's Parquet files and loading them into the local DuckDB database in the **background**, returning immediately — large exports can take longer than an AI client will wait on a single call. Poll `check_rapid7_export_status` with the same export ID until it reports the load is complete; that is when the data becomes queryable.
 
 ```
 Download and load export abc-123
@@ -499,7 +504,7 @@ Load parquet files from ~/.rapid7_mcp/imports/my-export/
 
 Executes SQL against the loaded data. The connection is locked down after loading — filesystem reads, writes, and network access are all blocked at the DuckDB engine level.
 
-Available tables: `assets`, `vulnerabilities`, `policies`, `vulnerability_remediation`.
+Available tables (depending on what you have loaded): `assets`, `vulnerabilities`, `vulnerability_exceptions`, `policies`, `vulnerability_remediation`, `asset_software`.
 
 ```
 Run: SELECT severity, COUNT(*) FROM vulnerabilities GROUP BY severity

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "rapid7-bulk-export",
   "display_name": "Rapid7 Bulk Export",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Export and analyze Rapid7 InsightVM vulnerability data via SQL queries",
   "long_description": "Connects to the Rapid7 Bulk Export API to fetch vulnerability and asset data, loads it into a local DuckDB database, and exposes SQL query tools for AI-powered security analysis. Supports export reuse, EPSS-based prioritization, and cross-cloud vulnerability tracking.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rapid7-vulnerability-export"
-version = "0.5.3"
+version = "0.6.0"
 description = "Python script to export vulnerability data from Rapid7 InsightVM using the Bulk Export API"
 requires-python = ">=3.10"
 dependencies = [

--- a/rapid7-bulk-export-skill/SKILL.md
+++ b/rapid7-bulk-export-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Rapid7 Bulk Export Analysis Expert
 description: Expert analysis of Rapid7 InsightVM data exported via Bulk Export API with strict MCP requirements
-version: 0.5.3
+version: 0.6.0
 author: Rapid7 Bulk Export MCP Tool
 tags: [security, vulnerabilities, rapid7, insightvm, bulk-export, analysis, policy, remediation]
 ---
@@ -21,9 +21,9 @@ This skill ONLY works with the Rapid7 MCP server. You must:
 1. **Verify MCP server is available** - Check if you have access to these tools:
    - `list_exports()` - Check available exports and their dates
    - `get_stats()` - Check if data is loaded (covers all tables)
-   - `start_export(export_type, start_date, end_date)` - Kick off any export type (instant, non-blocking)
-   - `check_export_status(export_id)` - Check export progress (instant)
-   - `download_and_load_export(export_id, export_type)` - Download and load a completed export
+   - `start_export(export_type, start_date, end_date)` - Kick off any export type (instant, non-blocking). For `remediation`, this starts a background job covering the whole date range and returns a job id.
+   - `check_export_status(export_id)` - Check progress once (instant, non-blocking). Reports the platform export status, the local download/load progress, or a remediation job's per-window progress. Accepts an export id or a remediation job id.
+   - `download_and_load_export(export_id, export_type)` - Start downloading a completed export and loading it in the background; poll `check_export_status(export_id)` until it reports the load is complete. (Not used for `remediation` — that is loaded by the job started in `start_export`.)
    - `query(sql)` - Execute SQL queries against all tables
    - `get_schema()` - View table schemas for all tables
 
@@ -35,7 +35,7 @@ This skill ONLY works with the Rapid7 MCP server. You must:
       - No data exists
       - Last export is older than 1 day
       - User requests fresh data
-   4. For a COMPLETE dataset, ensure all three export types have been run
+   4. For a COMPLETE dataset, ensure all four export types have been run
    ```
 
 3. **If MCP is not available**:
@@ -46,7 +46,7 @@ This skill ONLY works with the Rapid7 MCP server. You must:
 
 ## Data Source
 
-The data comes from Rapid7 InsightVM's Bulk Export API, which exports three types of data:
+The data comes from Rapid7 InsightVM's Bulk Export API, which exports four types of data:
 - **Asset & Vulnerability data**: All assets with agent-based scanning (including cloud identifiers for AWS, Azure, GCP) and all vulnerabilities found on assets (including CVSS v2/v3 scores, EPSS scores, exploit information, and best solution data if enabled for your org)
 - **Policy compliance data**: Agent-based and scan-based policy assessment results, including benchmark compliance status, rule pass/fail results, and remediation guidance
 - **Vulnerability remediation data**: Tracks vulnerability lifecycle — when vulnerabilities were first found, last detected, and last removed — for a specified date range
@@ -54,7 +54,7 @@ The data comes from Rapid7 InsightVM's Bulk Export API, which exports three type
 - **Export format**: Parquet files downloaded and loaded into DuckDB for SQL querying
 - **Data freshness**: Refreshed once daily by Rapid7; exports are retained for 30 days
 - **Schema**: Based on Rapid7's official Bulk Export API Parquet schema (see docs.rapid7.com/insightvm/bulk-export-api)
-- **Database tables**: Data is loaded into five tables: `assets`, `vulnerabilities`, `policies`, `vulnerability_remediation`, and `asset_software`
+- **Database tables**: Data is loaded into six tables: `assets`, `vulnerabilities`, `vulnerability_exceptions`, `policies`, `vulnerability_remediation`, and `asset_software`
 - **Export tracking**: The system tracks exports by type in `rapid7_bulk_export_tracking.db` to avoid redundant downloads
 
 ## Workflow - INTELLIGENT DATA LOADING
@@ -74,7 +74,7 @@ You should:
 
 ### Step 2: Start Exports (If Needed)
 ```
-To load a complete dataset, kick off all three exports, then poll and load each:
+To load a complete dataset, kick off all four exports, then poll and load each:
 
 1. Call start_export(export_type="vulnerability")
    → Save the vulnerability export_id
@@ -83,8 +83,12 @@ To load a complete dataset, kick off all three exports, then poll and load each:
    → Save the policy export_id
 
 3. Call start_export(export_type="remediation", start_date="YYYY-MM-DD", end_date="YYYY-MM-DD")
-   → Save the remediation export_id
+   → Save the remediation JOB ID (remediation returns a job id, not an export id)
    → Default to last 30 days if user doesn't specify dates
+   → A range longer than 31 days is split into ≤31-day windows and loaded
+     sequentially in the background as one job — you do NOT call
+     download_and_load_export for remediation; the job downloads and loads
+     every window itself and appends them into vulnerability_remediation.
 
 4. Call start_export(export_type="asset_software")
    → Save the asset_software export_id
@@ -99,13 +103,15 @@ All four calls return instantly with export IDs. Inform the user:
 4. Wait 30 seconds, then check each export:
    - check_export_status(export_id) for each
    - If still PENDING/PROCESSING, wait another 30 seconds and check again
-   - Repeat until all three are COMPLETE
+   - Repeat until all four are COMPLETE
 
 5. Once an export is COMPLETE, load it:
    - download_and_load_export(export_id, export_type="vulnerability")
    - download_and_load_export(export_id, export_type="policy")
-   - download_and_load_export(export_id, export_type="remediation")
    - download_and_load_export(export_id, export_type="asset_software")
+   Remediation is different: it was already started as a background job in
+   step 3. Poll it with check_export_status(job_id) until it reports the
+   whole range is loaded — do NOT call download_and_load_export for it.
 
 6. Inform the user:
    - "All exports loaded. X assets, Y vulnerabilities, Z policies,
@@ -318,7 +324,19 @@ The `vulnerability_remediation` table tracks the lifecycle of vulnerabilities �
 - `epssscore` (Double) - EPSS score (0-1, probability of exploitation in 30 days)
 - `epsspercentile` (Double) - EPSS percentile (0-1)
 
-### 5. Asset Software Table (`asset_software`)
+### 5. Vulnerability Exceptions Table (`vulnerability_exceptions`)
+
+The `vulnerability_exceptions` table lists findings that have been waived or
+accepted as risk (exceptions), so a finding present here is excluded from the
+active vulnerability posture. It is produced by the vulnerability export
+alongside `assets` and `vulnerabilities`. Join it to `vulnerabilities` on
+`assetId` + `vulnId` to distinguish live findings from accepted-risk ones.
+
+**Key fields:** `orgId`, `assetId`, `vulnId`, `checkId`, `key`, `port`,
+`protocol`, `nic`, `proof`, `firstFoundTimestamp`, `reintroducedTimestamp`,
+`exceptionDetails`
+
+### 6. Asset Software Table (`asset_software`)
 
 The `asset_software` table contains the installed software inventory for all IVM-managed assets. Each row represents one software package on one asset.
 
@@ -1045,7 +1063,7 @@ ORDER BY pciSeverity DESC;
 
 1. **Always check the schema first** - Use `get_schema()` to see available columns in all tables — especially important for `asset_software` and for confirming whether `bestSolution*` columns are present
 2. **Start with statistics** - Use `get_stats()` to understand the data distribution across all tables and confirm which tables are loaded
-3. **Know your tables** - Five tables: `assets`, `vulnerabilities`, `policies`, `vulnerability_remediation`, `asset_software`
+3. **Know your tables** - Six tables: `assets`, `vulnerabilities`, `vulnerability_exceptions`, `policies`, `vulnerability_remediation`, `asset_software`
 4. **Load all data types** - For comprehensive analysis, kick off all four exports: `start_export(export_type="vulnerability")`, `start_export(export_type="policy")`, `start_export(export_type="remediation")`, and `start_export(export_type="asset_software")`, then `check_export_status()` → `download_and_load_export()` for each.
 5. **Join when needed** - Use JOIN queries to correlate asset information with vulnerabilities, policies, or remediation data (all join on `assetId`)
 6. **Limit large queries** - Add `LIMIT` clauses when exploring data
@@ -1142,7 +1160,7 @@ If data seems stale:
 - **Check data freshness first**: Always call list_exports() and get_stats() before analysis
 - **Inform about data age**: Tell users which export date is being used
 - **Start with assets**: Understand your asset inventory before diving into vulnerabilities or policies
-- **Use all five tables**: Join `assets`, `vulnerabilities`, `policies`, `vulnerability_remediation`, and `asset_software` tables for comprehensive analysis
+- **Use all six tables**: Join `assets`, `vulnerabilities`, `vulnerability_exceptions`, `policies`, `vulnerability_remediation`, and `asset_software` tables for comprehensive analysis
 - **Prioritize by risk**: Combine cvssV3Score, severity, hasExploits, and epssscore for comprehensive risk assessment
 - **Consider context**: Asset criticality (from tags, assetGroups, riskScore) matters more than raw vulnerability count
 - **Track trends**: Compare current state to historical data using temporal fields

--- a/rapid7-bulk-export-skill/SKILL.md
+++ b/rapid7-bulk-export-skill/SKILL.md
@@ -10,7 +10,7 @@ tags: [security, vulnerabilities, rapid7, insightvm, bulk-export, analysis, poli
 
 **CRITICAL REQUIREMENTS:**
 1. The Rapid7 MCP server MUST be installed and configured
-2. You MUST ensure data is available before analysis (check with `get_stats()` or `list_exports()`)
+2. You MUST ensure data is available before analysis (check with `get_rapid7_stats()` or `list_rapid7_exports()`)
 3. Without these, you CANNOT help with analysis
 4. For a complete dataset, all four export types (vulnerability, policy, remediation, asset_software) MUST be loaded
 
@@ -19,18 +19,18 @@ tags: [security, vulnerabilities, rapid7, insightvm, bulk-export, analysis, poli
 This skill ONLY works with the Rapid7 MCP server. You must:
 
 1. **Verify MCP server is available** - Check if you have access to these tools:
-   - `list_exports()` - Check available exports and their dates
-   - `get_stats()` - Check if data is loaded (covers all tables)
-   - `start_export(export_type, start_date, end_date)` - Kick off any export type (instant, non-blocking). For `remediation`, this starts a background job covering the whole date range and returns a job id.
-   - `check_export_status(export_id)` - Check progress once (instant, non-blocking). Reports the platform export status, the local download/load progress, or a remediation job's per-window progress. Accepts an export id or a remediation job id.
-   - `download_and_load_export(export_id, export_type)` - Start downloading a completed export and loading it in the background; poll `check_export_status(export_id)` until it reports the load is complete. (Not used for `remediation` — that is loaded by the job started in `start_export`.)
-   - `query(sql)` - Execute SQL queries against all tables
-   - `get_schema()` - View table schemas for all tables
+   - `list_rapid7_exports()` - Check available exports and their dates
+   - `get_rapid7_stats()` - Check if data is loaded (covers all tables)
+   - `start_rapid7_export(export_type, start_date, end_date)` - Kick off any export type (instant, non-blocking). For `remediation`, this starts a background job covering the whole date range and returns a job id.
+   - `check_rapid7_export_status(export_id)` - Check progress once (instant, non-blocking). Reports the platform export status, the local download/load progress, or a remediation job's per-window progress. Accepts an export id or a remediation job id.
+   - `download_rapid7_export(export_id, export_type)` - Start downloading a completed export and loading it in the background; poll `check_rapid7_export_status(export_id)` until it reports the load is complete. (Not used for `remediation` — that is loaded by the job started in `start_rapid7_export`.)
+   - `query_rapid7(sql)` - Execute SQL queries against all tables
+   - `get_rapid7_schema()` - View table schemas for all tables
 
 2. **Check data availability FIRST** - Before ANY analysis:
    ```
-   1. Call list_exports() to see available exports
-   2. Call get_stats() to check if data is loaded
+   1. Call list_rapid7_exports() to see available exports
+   2. Call get_rapid7_stats() to check if data is loaded
    3. Only start a new export if:
       - No data exists
       - Last export is older than 1 day
@@ -64,8 +64,8 @@ The data comes from Rapid7 InsightVM's Bulk Export API, which exports four types
 FIRST ACTION: Check if data is already available
 
 You should:
-- Call list_exports() to see available exports and their dates
-- Call get_stats() to check if data is loaded and see row counts for all tables
+- Call list_rapid7_exports() to see available exports and their dates
+- Call get_rapid7_stats() to check if data is loaded and see row counts for all tables
 - If data exists and is from today, skip to Step 4 (analysis)
 - If no data or stale (>1 day old), proceed to Step 2
 - Check which export types have been loaded — for a complete dataset,
@@ -76,21 +76,21 @@ You should:
 ```
 To load a complete dataset, kick off all four exports, then poll and load each:
 
-1. Call start_export(export_type="vulnerability")
+1. Call start_rapid7_export(export_type="vulnerability")
    → Save the vulnerability export_id
 
-2. Call start_export(export_type="policy")
+2. Call start_rapid7_export(export_type="policy")
    → Save the policy export_id
 
-3. Call start_export(export_type="remediation", start_date="YYYY-MM-DD", end_date="YYYY-MM-DD")
+3. Call start_rapid7_export(export_type="remediation", start_date="YYYY-MM-DD", end_date="YYYY-MM-DD")
    → Save the remediation JOB ID (remediation returns a job id, not an export id)
    → Default to last 30 days if user doesn't specify dates
    → A range longer than 31 days is split into ≤31-day windows and loaded
      sequentially in the background as one job — you do NOT call
-     download_and_load_export for remediation; the job downloads and loads
+     download_rapid7_export for remediation; the job downloads and loads
      every window itself and appends them into vulnerability_remediation.
 
-4. Call start_export(export_type="asset_software")
+4. Call start_rapid7_export(export_type="asset_software")
    → Save the asset_software export_id
 
 All four calls return instantly with export IDs. Inform the user:
@@ -101,17 +101,17 @@ All four calls return instantly with export IDs. Inform the user:
 ### Step 3: Monitor and Load
 ```
 4. Wait 30 seconds, then check each export:
-   - check_export_status(export_id) for each
+   - check_rapid7_export_status(export_id) for each
    - If still PENDING/PROCESSING, wait another 30 seconds and check again
    - Repeat until all four are COMPLETE
 
 5. Once an export is COMPLETE, load it:
-   - download_and_load_export(export_id, export_type="vulnerability")
-   - download_and_load_export(export_id, export_type="policy")
-   - download_and_load_export(export_id, export_type="asset_software")
+   - download_rapid7_export(export_id, export_type="vulnerability")
+   - download_rapid7_export(export_id, export_type="policy")
+   - download_rapid7_export(export_id, export_type="asset_software")
    Remediation is different: it was already started as a background job in
-   step 3. Poll it with check_export_status(job_id) until it reports the
-   whole range is loaded — do NOT call download_and_load_export for it.
+   step 3. Poll it with check_rapid7_export_status(job_id) until it reports the
+   whole range is loaded — do NOT call download_rapid7_export for it.
 
 6. Inform the user:
    - "All exports loaded. X assets, Y vulnerabilities, Z policies,
@@ -345,7 +345,7 @@ The `asset_software` table contains the installed software inventory for all IVM
 - `orgId` (String) - Organization ID
 
 **Software Details:**
-- The exact column names for software name, version, vendor, and install date are schema-dependent — always call `get_schema()` to discover the current columns before querying this table.
+- The exact column names for software name, version, vendor, and install date are schema-dependent — always call `get_rapid7_schema()` to discover the current columns before querying this table.
 
 **Notes:**
 - This table is independent of the `vulnerabilities` table — it lists all installed software, not just software with known vulnerabilities.
@@ -423,7 +423,7 @@ Use EPSS (Exploit Prediction Scoring System) metrics:
 ### Software Inventory Analysis
 
 #### 1. Asset Software Inventory
-- Call `get_schema()` to discover current column names — the schema may evolve
+- Call `get_rapid7_schema()` to discover current column names — the schema may evolve
 - Join `asset_software` with `assets` on `assetId` to correlate software with asset metadata
 - Use for software license auditing, end-of-life software identification, and cross-referencing installed packages against vulnerability findings
 
@@ -710,11 +710,11 @@ LIMIT 25;
 
 ### Asset Software Queries
 
-> Always call `get_schema()` first — column names for the `asset_software` table may differ from examples below.
+> Always call `get_rapid7_schema()` first — column names for the `asset_software` table may differ from examples below.
 
 #### Software Inventory by Asset
 ```sql
--- Adjust column names based on get_schema() output
+-- Adjust column names based on get_rapid7_schema() output
 SELECT
     s.assetId,
     a.hostName,
@@ -1061,10 +1061,10 @@ ORDER BY pciSeverity DESC;
 
 ## Best Practices
 
-1. **Always check the schema first** - Use `get_schema()` to see available columns in all tables — especially important for `asset_software` and for confirming whether `bestSolution*` columns are present
-2. **Start with statistics** - Use `get_stats()` to understand the data distribution across all tables and confirm which tables are loaded
+1. **Always check the schema first** - Use `get_rapid7_schema()` to see available columns in all tables — especially important for `asset_software` and for confirming whether `bestSolution*` columns are present
+2. **Start with statistics** - Use `get_rapid7_stats()` to understand the data distribution across all tables and confirm which tables are loaded
 3. **Know your tables** - Six tables: `assets`, `vulnerabilities`, `vulnerability_exceptions`, `policies`, `vulnerability_remediation`, `asset_software`
-4. **Load all data types** - For comprehensive analysis, kick off all four exports: `start_export(export_type="vulnerability")`, `start_export(export_type="policy")`, `start_export(export_type="remediation")`, and `start_export(export_type="asset_software")`, then `check_export_status()` → `download_and_load_export()` for each.
+4. **Load all data types** - For comprehensive analysis, kick off all four exports: `start_rapid7_export(export_type="vulnerability")`, `start_rapid7_export(export_type="policy")`, `start_rapid7_export(export_type="remediation")`, and `start_rapid7_export(export_type="asset_software")`, then `check_rapid7_export_status()` → `download_rapid7_export()` for each.
 5. **Join when needed** - Use JOIN queries to correlate asset information with vulnerabilities, policies, or remediation data (all join on `assetId`)
 6. **Limit large queries** - Add `LIMIT` clauses when exploring data
 7. **Use appropriate filters** - Filter by severity, cvssV3Score, osFamily, cloud provider, finalStatus, source, etc.
@@ -1077,40 +1077,40 @@ ORDER BY pciSeverity DESC;
 14. **Asset-first analysis** - Start with asset queries to understand your environment before diving into vulnerabilities or policies
 15. **Cloud awareness** - Use cloud identifiers (awsInstanceId, azureResourceId, gcpObjectId) to segment analysis by provider
 16. **Policy source awareness** - Use the `source` column in the `policies` table to distinguish between agent-based (`'agent'`) and scan-based (`'scan'`) assessments. Compare results from both sources to identify coverage gaps.
-17. **Remediation date ranges** - The `vulnerability_remediation` table contains data for a specific date range. Check which range was exported using `list_exports()` to understand the scope of your remediation data.
+17. **Remediation date ranges** - The `vulnerability_remediation` table contains data for a specific date range. Check which range was exported using `list_rapid7_exports()` to understand the scope of your remediation data.
 18. **Track remediation velocity** - Use `firstFoundTimestamp` and `lastRemoved` in the `vulnerability_remediation` table to calculate mean time to remediate (MTTR) and track improvement over time.
 19. **Best solution awareness** - `bestSolution*` columns in `vulnerabilities` are only present if your org is enabled for this feature. Always check `bestSolutionType IS NOT NULL` before using them. `UNKNOWN`/null types have no fix data — skip them in actionable reports. `WORKAROUND` does not mean "no patch" — show `bestSolutionSummary` instead of the type label. Strip HTML from `bestSolutionFix` before displaying.
-20. **Asset software schema** - The `asset_software` table schema may evolve. Always call `get_schema()` to discover current column names before querying — don't assume column names from examples.
+20. **Asset software schema** - The `asset_software` table schema may evolve. Always call `get_rapid7_schema()` to discover current column names before querying — don't assume column names from examples.
 
 ## Integration with MCP - REQUIRED
 
 The MCP server provides these tools:
 
 **Export Tools (non-blocking):**
-- `start_export(export_type, start_date, end_date)` — Kick off any export type (instant). `export_type` is one of `"vulnerability"`, `"policy"`, `"remediation"`, or `"asset_software"`. `start_date` and `end_date` are only used for remediation exports (YYYY-MM-DD format, defaults to last 30 days).
-- `check_export_status(export_id)` — Check if an export is done (instant)
-- `download_and_load_export(export_id, export_type)` — Download completed export and load into DB (~1 min). Pass the same `export_type` used in `start_export`.
+- `start_rapid7_export(export_type, start_date, end_date)` — Kick off any export type (instant). `export_type` is one of `"vulnerability"`, `"policy"`, `"remediation"`, or `"asset_software"`. `start_date` and `end_date` are only used for remediation exports (YYYY-MM-DD format, defaults to last 30 days).
+- `check_rapid7_export_status(export_id)` — Check if an export is done (instant)
+- `download_rapid7_export(export_id, export_type)` — Download completed export and load into DB (~1 min). Pass the same `export_type` used in `start_rapid7_export`.
 
 **Data Management Tools:**
-- `list_exports(limit=10)` - List recent exports with dates, types, and metadata (check this FIRST)
-- `get_stats()` - Get summary statistics for all tables and verify data is loaded
+- `list_rapid7_exports(limit=10)` - List recent exports with dates, types, and metadata (check this FIRST)
+- `get_rapid7_stats()` - Get summary statistics for all tables and verify data is loaded
 - `load_from_parquet(parquet_path)` - Load from existing Parquet files (advanced use)
 
 **Query Tools:**
 - `query(sql="...")` - Execute SQL queries against all tables (`assets`, `vulnerabilities`, `policies`, `vulnerability_remediation`, `asset_software`)
-- `get_schema()` - Get table schema for all existing tables
+- `get_rapid7_schema()` - Get table schema for all existing tables
 
 **Recommended Workflow:**
-1. Call `list_exports()` — do we have data from today for all needed export types?
-2. Call `get_stats()` — is data loaded in the database for all tables?
+1. Call `list_rapid7_exports()` — do we have data from today for all needed export types?
+2. Call `get_rapid7_stats()` — is data loaded in the database for all tables?
 3. If no data or stale:
-   a. `start_export(export_type="vulnerability")` → save export_id
-   b. `start_export(export_type="policy")` → save export_id
-   c. `start_export(export_type="remediation", start_date="...", end_date="...")` → save export_id
-   d. `start_export(export_type="asset_software")` → save export_id
-   e. Wait 30s, then `check_export_status(export_id)` for each
-   f. Once COMPLETE: `download_and_load_export(export_id, export_type="...")` for each
-4. Proceed with `query()`, `get_schema()`, `get_stats()`
+   a. `start_rapid7_export(export_type="vulnerability")` → save export_id
+   b. `start_rapid7_export(export_type="policy")` → save export_id
+   c. `start_rapid7_export(export_type="remediation", start_date="...", end_date="...")` → save export_id
+   d. `start_rapid7_export(export_type="asset_software")` → save export_id
+   e. Wait 30s, then `check_rapid7_export_status(export_id)` for each
+   f. Once COMPLETE: `download_rapid7_export(export_id, export_type="...")` for each
+4. Proceed with `query()`, `get_rapid7_schema()`, `get_rapid7_stats()`
 
 ## Error Handling
 
@@ -1120,44 +1120,44 @@ If you cannot access MCP tools:
 3. Direct them to README for setup instructions
 4. DO NOT proceed with analysis
 
-If get_stats() shows no data:
-1. Call list_exports() to check for available exports
-2. If a COMPLETE export exists, call download_and_load_export(export_id, export_type="...")
+If get_rapid7_stats() shows no data:
+1. Call list_rapid7_exports() to check for available exports
+2. If a COMPLETE export exists, call download_rapid7_export(export_id, export_type="...")
 3. If no exports exist or last export is >1 day old:
-   a. Call start_export(export_type="vulnerability") for vulnerability data
-   b. Call start_export(export_type="policy") for policy data
-   c. Call start_export(export_type="remediation", start_date="...", end_date="...") for remediation data
-   d. Call start_export(export_type="asset_software") for software inventory data
+   a. Call start_rapid7_export(export_type="vulnerability") for vulnerability data
+   b. Call start_rapid7_export(export_type="policy") for policy data
+   c. Call start_rapid7_export(export_type="remediation", start_date="...", end_date="...") for remediation data
+   d. Call start_rapid7_export(export_type="asset_software") for software inventory data
 4. Inform user: "No data available. Starting exports — each takes 3-5 minutes."
 
-If start_export() fails:
+If start_rapid7_export() fails:
 1. Show the error to the user
 2. Common issues: RAPID7_API_KEY not set, invalid key, invalid region, network issues
 3. DO NOT proceed without data
 
-If check_export_status() shows FAILED:
+If check_rapid7_export_status() shows FAILED:
 1. Inform user the export failed
-2. Offer to retry with start_export(export_type="...")
+2. Offer to retry with start_rapid7_export(export_type="...")
 
-If download_and_load_export() fails:
+If download_rapid7_export() fails:
 1. Show the error — the export ID is included in the response
 2. The user can retry with the same export ID
 3. DO NOT proceed without data
 
-If start_export(export_type="remediation") fails with date validation error:
+If start_rapid7_export(export_type="remediation") fails with date validation error:
 1. Check that dates are in YYYY-MM-DD format
 2. Ensure start_date != end_date
 3. Ensure the date range does not exceed 31 days
 4. Retry with corrected dates
 
 If data seems stale:
-1. Check list_exports() to see export date
+1. Check list_rapid7_exports() to see export date
 2. Inform user: "Current data is from [date]. Would you like to refresh?"
-3. Only call start_export() if user confirms
+3. Only call start_rapid7_export() if user confirms
 
 ## Tips for Analysis
 
-- **Check data freshness first**: Always call list_exports() and get_stats() before analysis
+- **Check data freshness first**: Always call list_rapid7_exports() and get_rapid7_stats() before analysis
 - **Inform about data age**: Tell users which export date is being used
 - **Start with assets**: Understand your asset inventory before diving into vulnerabilities or policies
 - **Use all six tables**: Join `assets`, `vulnerabilities`, `vulnerability_exceptions`, `policies`, `vulnerability_remediation`, and `asset_software` tables for comprehensive analysis

--- a/src/duckdb_loader.py
+++ b/src/duckdb_loader.py
@@ -127,7 +127,9 @@ class VulnerabilityDatabase:
                 Default False preserves snapshot-replace behavior.
 
         Returns:
-            Dict mapping table names to total row counts loaded.
+            Dict mapping table names to the number of rows inserted by THIS
+            call (a delta, not the table's cumulative total) — so appended
+            windows report only their own rows.
         """
         if skip_prefixes is None:
             skip_prefixes = set()
@@ -163,6 +165,15 @@ class VulnerabilityDatabase:
             preexisting: Set[str] = {
                 row[0] for row in conn.execute("SELECT table_name FROM information_schema.tables").fetchall()
             }
+
+            # Row count of each pre-existing table BEFORE this call's inserts, so
+            # the returned counts are rows-inserted-this-call (a delta), not the
+            # table's cumulative total. Critical for append mode: without this,
+            # N appended windows of R rows each would report R, 2R, 3R, ...
+            counts_before: Dict[str, int] = {}
+            for table_name in preexisting:
+                result = conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()  # nosec B608
+                counts_before[table_name] = result[0] if result else 0
 
             for prefix, file_paths in prefix_file_map.items():
                 if prefix in skip_prefixes:
@@ -209,10 +220,12 @@ class VulnerabilityDatabase:
                         )
                         continue
 
-            # Collect row counts only for tables we actually touched
+            # Report rows inserted BY THIS CALL: current total minus the
+            # pre-call baseline (0 for tables created in this call).
             for table_name in tables_touched:
                 result = conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()  # nosec B608
-                row_counts[table_name] = result[0] if result else 0
+                after = result[0] if result else 0
+                row_counts[table_name] = after - counts_before.get(table_name, 0)
 
         # Reclaim disk space from dropped tables. DuckDB does not shrink the file
         # on DROP TABLE or VACUUM — the only way is to copy to a fresh database.

--- a/src/export_manager.py
+++ b/src/export_manager.py
@@ -14,6 +14,25 @@ from typing import Any, Dict, List, Optional, Tuple
 from .graphql_client import send_graphql_request
 
 
+class ExportInProgressError(ValueError):
+    """Raised when the platform rejects a create because an export of the same
+    type is already in flight.
+
+    The platform allows only one export per type at a time. For unparameterised
+    snapshot exports (vulnerability, policy, asset_software) the in-flight export
+    is an acceptable substitute, so those paths catch this and return
+    ``export_id``. For remediation the in-flight export is scoped to a date range
+    that may not match what was requested, so the caller must wait and recreate
+    its own chunk rather than adopt a foreign id.
+
+    Subclasses ValueError so existing ``except ValueError`` handlers still catch it.
+    """
+
+    def __init__(self, export_id: str):
+        self.export_id = export_id
+        super().__init__(f"An export of this type is already in progress: {export_id}")
+
+
 def _extract_in_progress_id(error_msg: str) -> Optional[str]:
     """Extract an in-progress export ID from a Rapid7 'already in-progress' error message."""
     if "already in-progress" in error_msg and "exportId:" in error_msg:
@@ -35,6 +54,9 @@ def _create_simple_export(config: Dict[str, str], mutation_name: str, response_k
     try:
         response = send_graphql_request(endpoint=config["endpoint"], api_key=config["api_key"], query=mutation)
         return response["data"][response_key]["id"]
+    except ExportInProgressError as e:
+        # Snapshot exports are unparameterised, so reusing the in-flight one is fine.
+        return e.export_id
     except ValueError as e:
         export_id = _extract_in_progress_id(str(e))
         if export_id:
@@ -128,8 +150,11 @@ def create_remediation_export(config: Dict[str, str], start_date: str, end_date:
     export job. The returned ID can be used to poll for status and retrieve
     download URLs when complete.
 
-    If an export is already in progress, returns the existing export ID from
-    the error message.
+    If an export of this type is already in flight, raises
+    ExportInProgressError carrying the in-flight export's ID (the platform
+    allows only one export per type at a time). The caller must wait and
+    recreate its own chunk rather than adopt that ID, since a remediation
+    export is scoped to a specific date range.
 
     Args:
         config: Configuration dictionary containing endpoint and api_key.
@@ -141,7 +166,8 @@ def create_remediation_export(config: Dict[str, str], start_date: str, end_date:
 
     Raises:
         ValueError: If date validation fails or the response contains
-            GraphQL errors (except in-progress)
+            GraphQL errors
+        ExportInProgressError: If an export of this type is already in flight
         requests.HTTPError: If the HTTP response status code is not 200
         requests.RequestException: If the network request fails
     """
@@ -187,7 +213,10 @@ def create_remediation_export(config: Dict[str, str], start_date: str, end_date:
     except ValueError as e:
         export_id = _extract_in_progress_id(str(e))
         if export_id:
-            return export_id
+            # A remediation export is scoped to a date range; the in-flight one
+            # may cover a different window, so we must NOT return it as if it
+            # were this chunk's. Signal the caller to wait and recreate.
+            raise ExportInProgressError(export_id) from e
         raise
 
 

--- a/src/export_tracker.py
+++ b/src/export_tracker.py
@@ -56,6 +56,9 @@ class ExportTracker:
                 # Full summary or error text produced once a load reaches a
                 # terminal state, so the status tools can echo it verbatim.
                 "ADD COLUMN message VARCHAR",
+                # Last phase-transition time. Kept separate from created_at so
+                # a load's progress updates never overwrite its creation time.
+                "ADD COLUMN updated_at TIMESTAMP",
             ):
                 try:
                     conn.execute(f"ALTER TABLE exports {column_ddl}")
@@ -234,7 +237,7 @@ class ExportTracker:
                     phase_detail = ?,
                     message = ?,
                     row_count = COALESCE(?, row_count),
-                    created_at = ?
+                    updated_at = ?
                 WHERE export_id = ?
                 """,
                 [status, phase_detail, message, row_count, now, export_id],
@@ -334,6 +337,59 @@ class ExportTracker:
             "updated_at": result[9],
         }
 
+    def has_active_work(self, active_export_statuses: List[str], active_job_statuses: List[str]) -> bool:
+        """Return True if any export or job is in an active (in-flight) state.
+
+        Used to refuse a purge while a background download/load or a
+        multi-window job is still running — the caller's DB lock only covers
+        the load phase, not the polling/downloading/between-window gaps.
+        """
+        with duckdb_connection(self.db_path) as conn:
+            if active_export_statuses:
+                placeholders = ", ".join("?" for _ in active_export_statuses)
+                row = conn.execute(
+                    f"SELECT COUNT(*) FROM exports WHERE status IN ({placeholders})",  # nosec B608
+                    active_export_statuses,
+                ).fetchone()
+                if row and row[0] > 0:
+                    return True
+            if active_job_statuses:
+                placeholders = ", ".join("?" for _ in active_job_statuses)
+                row = conn.execute(
+                    f"SELECT COUNT(*) FROM export_jobs WHERE status IN ({placeholders})",  # nosec B608
+                    active_job_statuses,
+                ).fetchone()
+                if row and row[0] > 0:
+                    return True
+        return False
+
+    def reconcile_interrupted(
+        self, active_export_statuses: List[str], active_job_statuses: List[str], reason: str
+    ) -> None:
+        """Flip rows left in an active phase by a crash/restart to FAILED.
+
+        Background workers are daemon threads with no resume, so an export
+        interrupted mid-run would otherwise sit in DOWNLOADING/LOADING/RUNNING
+        forever and block retry as "already in progress". Called once at
+        startup.
+        """
+        now = datetime.now()
+        with duckdb_connection(self.db_path) as conn:
+            if active_export_statuses:
+                placeholders = ", ".join("?" for _ in active_export_statuses)
+                conn.execute(
+                    f"UPDATE exports SET status = 'FAILED', message = ?, updated_at = ? "  # nosec B608
+                    f"WHERE status IN ({placeholders})",
+                    [reason, now, *active_export_statuses],
+                )
+            if active_job_statuses:
+                placeholders = ", ".join("?" for _ in active_job_statuses)
+                conn.execute(
+                    f"UPDATE export_jobs SET status = 'FAILED', message = ?, updated_at = ? "  # nosec B608
+                    f"WHERE status IN ({placeholders})",
+                    [reason, now, *active_job_statuses],
+                )
+
     def get_export_by_id(self, export_id: str) -> Optional[Dict[str, Any]]:
         """
         Get export metadata by export ID.
@@ -360,7 +416,8 @@ class ExportTracker:
                     local_files,
                     export_type,
                     phase_detail,
-                    message
+                    message,
+                    updated_at
                 FROM exports
                 WHERE export_id = ?
             """,
@@ -380,6 +437,7 @@ class ExportTracker:
                 "export_type": result[8],
                 "phase_detail": result[9],
                 "message": result[10],
+                "updated_at": result[11],
             }
 
         return None

--- a/src/export_tracker.py
+++ b/src/export_tracker.py
@@ -5,6 +5,7 @@ This module manages a separate DuckDB database to track Rapid7 export metadata,
 allowing reuse of exports from the same day instead of creating new ones.
 """
 
+import json
 import os
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
@@ -66,6 +67,26 @@ class ExportTracker:
             conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_export_date_type
                 ON exports(export_date, export_type)
+            """)
+
+            # Multi-chunk load jobs (e.g. a remediation range split into
+            # <=31-day windows). One row groups the N per-chunk export IDs
+            # under a single logical job so the whole range is polled and
+            # resumed as one unit. `chunks` holds the ordered per-window plan
+            # as JSON: [{start, end, export_id, status}].
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS export_jobs (
+                    job_id VARCHAR PRIMARY KEY,
+                    export_type VARCHAR NOT NULL,
+                    start_date DATE NOT NULL,
+                    end_date DATE NOT NULL,
+                    status VARCHAR NOT NULL,
+                    current_index INTEGER,
+                    chunks VARCHAR NOT NULL,
+                    message VARCHAR,
+                    created_at TIMESTAMP NOT NULL,
+                    updated_at TIMESTAMP NOT NULL
+                )
             """)
 
     def get_today_export(self, export_type: str = "vulnerability") -> Optional[Dict[str, Any]]:
@@ -218,6 +239,100 @@ class ExportTracker:
                 """,
                 [status, phase_detail, message, row_count, now, export_id],
             )
+
+    def create_job(
+        self,
+        job_id: str,
+        export_type: str,
+        start_date: str,
+        end_date: str,
+        chunks: List[Dict[str, Any]],
+        status: str,
+    ) -> None:
+        """Create a multi-chunk load job row.
+
+        Args:
+            job_id: Unique job identifier.
+            export_type: Export type (currently only 'remediation' uses jobs).
+            start_date: Overall range start (YYYY-MM-DD).
+            end_date: Overall range end (YYYY-MM-DD).
+            chunks: Ordered per-window plan; each dict has start, end,
+                export_id (None until created), and status.
+            status: Initial job status.
+        """
+        now = datetime.now()
+        with duckdb_connection(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO export_jobs (
+                    job_id, export_type, start_date, end_date, status,
+                    current_index, chunks, message, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (job_id) DO UPDATE SET
+                    export_type = EXCLUDED.export_type,
+                    start_date = EXCLUDED.start_date,
+                    end_date = EXCLUDED.end_date,
+                    status = EXCLUDED.status,
+                    current_index = EXCLUDED.current_index,
+                    chunks = EXCLUDED.chunks,
+                    message = EXCLUDED.message,
+                    updated_at = EXCLUDED.updated_at
+                """,
+                [job_id, export_type, start_date, end_date, status, 0, json.dumps(chunks), None, now, now],
+            )
+
+    def update_job(
+        self,
+        job_id: str,
+        status: Optional[str] = None,
+        current_index: Optional[int] = None,
+        chunks: Optional[List[Dict[str, Any]]] = None,
+        message: Optional[str] = None,
+    ) -> None:
+        """Update the mutable fields of a job. Omitted fields are left unchanged."""
+        now = datetime.now()
+        with duckdb_connection(self.db_path) as conn:
+            conn.execute(
+                """
+                UPDATE export_jobs
+                SET status = COALESCE(?, status),
+                    current_index = COALESCE(?, current_index),
+                    chunks = COALESCE(?, chunks),
+                    message = COALESCE(?, message),
+                    updated_at = ?
+                WHERE job_id = ?
+                """,
+                [status, current_index, json.dumps(chunks) if chunks is not None else None, message, now, job_id],
+            )
+
+    def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
+        """Return a job row with `chunks` decoded to a list, or None."""
+        with duckdb_connection(self.db_path) as conn:
+            result = conn.execute(
+                """
+                SELECT job_id, export_type, start_date, end_date, status,
+                       current_index, chunks, message, created_at, updated_at
+                FROM export_jobs
+                WHERE job_id = ?
+                """,
+                [job_id],
+            ).fetchone()
+
+        if not result:
+            return None
+
+        return {
+            "job_id": result[0],
+            "export_type": result[1],
+            "start_date": result[2],
+            "end_date": result[3],
+            "status": result[4],
+            "current_index": result[5],
+            "chunks": json.loads(result[6]) if result[6] else [],
+            "message": result[7],
+            "created_at": result[8],
+            "updated_at": result[9],
+        }
 
     def get_export_by_id(self, export_id: str) -> Optional[Dict[str, Any]]:
         """

--- a/src/export_tracker.py
+++ b/src/export_tracker.py
@@ -384,11 +384,48 @@ class ExportTracker:
                 )
             if active_job_statuses:
                 placeholders = ", ".join("?" for _ in active_job_statuses)
-                conn.execute(
-                    f"UPDATE export_jobs SET status = 'FAILED', message = ?, updated_at = ? "  # nosec B608
+                rows = conn.execute(
+                    f"SELECT job_id, start_date, end_date, chunks FROM export_jobs "  # nosec B608
                     f"WHERE status IN ({placeholders})",
-                    [reason, now, *active_job_statuses],
-                )
+                    active_job_statuses,
+                ).fetchall()
+                for job_id, jstart, jend, chunks_json in rows:
+                    chunks = json.loads(chunks_json) if chunks_json else []
+                    loaded = [f"{c['start']} → {c['end']}" for c in chunks if c.get("status") == "loaded"]
+                    missing = [f"{c['start']} → {c['end']}" for c in chunks if c.get("status") != "loaded"]
+                    # Report per-window state so the user re-runs ONLY the
+                    # missing windows, never the whole range (which would
+                    # duplicate already-appended rows).
+                    job_msg = (
+                        f"✗ Interrupted by a server restart. "
+                        f"Loaded windows (kept): {', '.join(loaded) or 'none'}. "
+                        f"Missing windows: {', '.join(missing) or 'none'}. "
+                        f"Re-run only the missing range(s) with "
+                        f'start_rapid7_export(export_type="remediation", start_date=..., end_date=...).'
+                    )
+                    conn.execute(
+                        "UPDATE export_jobs SET status = 'FAILED', message = ?, updated_at = ? WHERE job_id = ?",
+                        [job_msg, now, job_id],
+                    )
+
+    def find_job_by_range(self, export_type: str, start_date: str, end_date: str) -> Optional[Dict[str, Any]]:
+        """Return the most recent job for an exact export_type + date range, or None.
+
+        Lets the remediation tool be idempotent: a repeated call for the same
+        range can reuse a RUNNING job or return a COMPLETE job's result rather
+        than starting a second worker that would append the windows again.
+        """
+        with duckdb_connection(self.db_path) as conn:
+            result = conn.execute(
+                """
+                SELECT job_id FROM export_jobs
+                WHERE export_type = ? AND start_date = ? AND end_date = ?
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                [export_type, start_date, end_date],
+            ).fetchone()
+        return self.get_job(result[0]) if result else None
 
     def get_export_by_id(self, export_id: str) -> Optional[Dict[str, Any]]:
         """

--- a/src/export_tracker.py
+++ b/src/export_tracker.py
@@ -44,14 +44,23 @@ class ExportTracker:
                 )
             """)
 
-            # Migrate schema: add export_type column for existing databases
-            try:
-                conn.execute("""
-                    ALTER TABLE exports ADD COLUMN export_type VARCHAR DEFAULT 'vulnerability'
-                """)
-            except Exception:
-                # Column already exists, ignore
-                pass  # nosec B110
+            # Migrate schema: add columns for existing databases. Each ALTER is
+            # idempotent — a second run raises because the column exists, which
+            # we swallow.
+            for column_ddl in (
+                "ADD COLUMN export_type VARCHAR DEFAULT 'vulnerability'",
+                # Human-readable progress detail for an in-flight load
+                # (e.g. "3 / 8 files downloaded"). NULL when not applicable.
+                "ADD COLUMN phase_detail VARCHAR",
+                # Full summary or error text produced once a load reaches a
+                # terminal state, so the status tools can echo it verbatim.
+                "ADD COLUMN message VARCHAR",
+            ):
+                try:
+                    conn.execute(f"ALTER TABLE exports {column_ddl}")
+                except Exception:
+                    # Column already exists, ignore
+                    pass  # nosec B110
 
             # Create index on export_date and export_type for fast lookups
             conn.execute("""
@@ -71,7 +80,12 @@ class ExportTracker:
         """
         today = date.today()
 
-        with duckdb_connection(self.db_path, read_only=True) as conn:
+        # NOTE: opened read-write (not read_only) on purpose. DuckDB refuses a
+        # read-only connection while a read-write connection to the same file
+        # is open in-process, and the background load holds a read-write
+        # handle while writing phase updates. A read-write handle for a
+        # SELECT is harmless and avoids that config-mismatch conflict.
+        with duckdb_connection(self.db_path) as conn:
             result = conn.execute(
                 """
                 SELECT
@@ -167,6 +181,44 @@ class ExportTracker:
                 ],
             )
 
+    def set_phase(
+        self,
+        export_id: str,
+        status: str,
+        phase_detail: Optional[str] = None,
+        message: Optional[str] = None,
+        row_count: Optional[int] = None,
+    ):
+        """Update only the live-phase fields of an already-tracked export.
+
+        Used by the background download/load worker to record progress
+        (DOWNLOADING, LOADING) and terminal outcomes (COMPLETE, FAILED)
+        without rewriting the parquet URLs or other metadata that
+        save_export owns. The row must already exist (start_rapid7_export
+        inserts it at PENDING); if it does not, this is a no-op update.
+
+        Args:
+            export_id: The Rapid7 export ID.
+            status: New status/phase value.
+            phase_detail: Optional human-readable progress string.
+            message: Optional terminal summary/error text.
+            row_count: Optional loaded-row count (set on COMPLETE).
+        """
+        now = datetime.now()
+        with duckdb_connection(self.db_path) as conn:
+            conn.execute(
+                """
+                UPDATE exports
+                SET status = ?,
+                    phase_detail = ?,
+                    message = ?,
+                    row_count = COALESCE(?, row_count),
+                    created_at = ?
+                WHERE export_id = ?
+                """,
+                [status, phase_detail, message, row_count, now, export_id],
+            )
+
     def get_export_by_id(self, export_id: str) -> Optional[Dict[str, Any]]:
         """
         Get export metadata by export ID.
@@ -177,7 +229,9 @@ class ExportTracker:
         Returns:
             Dictionary with export metadata if found, None otherwise
         """
-        with duckdb_connection(self.db_path, read_only=True) as conn:
+        # Read-write handle for a SELECT (see get_today_export note): avoids a
+        # DuckDB config-mismatch when the background load holds a write handle.
+        with duckdb_connection(self.db_path) as conn:
             result = conn.execute(
                 """
                 SELECT
@@ -188,7 +242,10 @@ class ExportTracker:
                     file_count,
                     row_count,
                     parquet_urls,
-                    local_files
+                    local_files,
+                    export_type,
+                    phase_detail,
+                    message
                 FROM exports
                 WHERE export_id = ?
             """,
@@ -205,6 +262,9 @@ class ExportTracker:
                 "row_count": result[5],
                 "parquet_urls": result[6],
                 "local_files": result[7],
+                "export_type": result[8],
+                "phase_detail": result[9],
+                "message": result[10],
             }
 
         return None
@@ -221,7 +281,8 @@ class ExportTracker:
             List of export metadata dictionaries
         """
         sql = """
-            SELECT export_id, export_date, created_at, status, file_count, row_count, export_type
+            SELECT export_id, export_date, created_at, status, file_count, row_count,
+                   export_type, phase_detail
             FROM exports
         """
         params: list = []
@@ -231,7 +292,9 @@ class ExportTracker:
         sql += " ORDER BY created_at DESC LIMIT ?"
         params.append(limit)
 
-        with duckdb_connection(self.db_path, read_only=True) as conn:
+        # Read-write handle for a SELECT (see get_today_export note): avoids a
+        # DuckDB config-mismatch when the background load holds a write handle.
+        with duckdb_connection(self.db_path) as conn:
             results = conn.execute(sql, params).fetchall()
 
         return [
@@ -243,6 +306,7 @@ class ExportTracker:
                 "file_count": row[4],
                 "row_count": row[5],
                 "export_type": row[6],
+                "phase_detail": row[7],
             }
             for row in results
         ]

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -13,8 +13,10 @@ import os
 import shutil
 import sys
 import tempfile
+import threading
+import traceback
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import duckdb as _duckdb
 from fastmcp import FastMCP
@@ -44,6 +46,46 @@ db: Optional[VulnerabilityDatabase] = None
 _DATA_DIR: Path = Path(os.environ.get("DATA_DIR", "~/.rapid7_mcp")).expanduser().resolve()
 
 VALID_EXPORT_TYPES = ("vulnerability", "policy", "remediation", "asset_software")
+
+# ---------------------------------------------------------------------------
+# Background download/load job tracking
+#
+# Loading a full export (potentially millions of rows) can take much longer
+# than an MCP client's tool-call timeout — Claude Desktop, for example,
+# hard-cancels a tool call after ~4 minutes. Running the download+load
+# synchronously inside a single tool call means the client gives up and
+# cancels while the server keeps working, and when the server later tries
+# to respond to that already-cancelled request, some MCP client/session
+# implementations raise on a duplicate response and crash the whole stdio
+# server process.
+#
+# To avoid this, download_rapid7_export() only *starts* the work in a
+# background thread and returns immediately. Progress and results are
+# tracked here and can be polled with check_download_status().
+# ---------------------------------------------------------------------------
+
+# export_id -> job info dict. Guarded by _jobs_lock.
+_download_jobs: Dict[str, Dict[str, Any]] = {}
+_jobs_lock = threading.Lock()
+
+# Guards all access to the shared `db` connection (both the background
+# load and the read tools below) so a query can never run concurrently
+# with a table being dropped/recreated mid-load.
+_db_lock = threading.Lock()
+
+
+def _set_job(export_id: str, **fields: Any) -> None:
+    """Create or update a job's tracked state."""
+    with _jobs_lock:
+        job = _download_jobs.setdefault(export_id, {})
+        job.update(fields)
+        job["updated_at"] = _dt.datetime.now().isoformat(timespec="seconds")
+
+
+def _get_job(export_id: str) -> Optional[Dict[str, Any]]:
+    with _jobs_lock:
+        job = _download_jobs.get(export_id)
+        return dict(job) if job is not None else None
 
 
 def initialize_database(db_path: Optional[str] = None) -> VulnerabilityDatabase:
@@ -105,37 +147,46 @@ def load_rapid7_parquet(parquet_path: str) -> str:
         if not parquet_files:
             return f"✗ Error: No Parquet files found at: {resolved}"
 
-        # Initialize database if needed
-        if db is None:
-            initialize_database()
+        if not _db_lock.acquire(blocking=False):
+            return (
+                "⏳ A background download/load is currently in progress. "
+                "Try again shortly, or check "
+                "check_download_status(export_id=...) for progress."
+            )
+        try:
+            # Initialize database if needed
+            if db is None:
+                initialize_database()
 
-        # Detect file types by peeking at schema and build prefix map
-        prefix_file_map: dict = {}
-        for pf in parquet_files:
-            try:
-                cols = [
-                    desc[0]
-                    for desc in _duckdb.execute(
-                        f"SELECT * FROM read_parquet('{pf}') LIMIT 0"  # nosec B608
-                    ).description
-                ]
-                if "vulnId" in cols or "checkId" in cols:
-                    prefix_file_map.setdefault("asset_vulnerability", []).append(pf)
-                else:
-                    prefix_file_map.setdefault("asset", []).append(pf)
-            except Exception:
-                # If we can't determine type, skip the file
-                continue
+            # Detect file types by peeking at schema and build prefix map
+            prefix_file_map: dict = {}
+            for pf in parquet_files:
+                try:
+                    cols = [
+                        desc[0]
+                        for desc in _duckdb.execute(
+                            f"SELECT * FROM read_parquet('{pf}') LIMIT 0"  # nosec B608
+                        ).description
+                    ]
+                    if "vulnId" in cols or "checkId" in cols:
+                        prefix_file_map.setdefault("asset_vulnerability", []).append(pf)
+                    else:
+                        prefix_file_map.setdefault("asset", []).append(pf)
+                except Exception:
+                    # If we can't determine type, skip the file
+                    continue
 
-        if not prefix_file_map:
-            return f"✗ Error: Could not determine schema for any Parquet files at: {resolved}"
+            if not prefix_file_map:
+                return f"✗ Error: Could not determine schema for any Parquet files at: {resolved}"
 
-        # Load into database
-        row_counts = db.load_parquet_files_by_prefix(prefix_file_map)
-        row_count = sum(row_counts.values())
+            # Load into database
+            row_counts = db.load_parquet_files_by_prefix(prefix_file_map)
+            row_count = sum(row_counts.values())
 
-        # Get statistics
-        stats = db.get_stats()
+            # Get statistics
+            stats = db.get_stats()
+        finally:
+            _db_lock.release()
 
         return (
             f"✓ Successfully loaded {row_count} rows from {len(parquet_files)} file(s).\n\n"
@@ -364,6 +415,116 @@ def check_rapid7_export_status(export_id: str) -> str:
         return f"✗ Error checking export status: {str(e)}"
 
 
+def _run_download_and_load(export_id: str, export_type: str) -> None:
+    """Background worker: download parquet files and load them into DuckDB.
+
+    Runs in its own thread. All progress/results are written to
+    _download_jobs[export_id] rather than returned, since nothing is
+    waiting on a function return here. Any exception is caught and stored
+    so check_download_status() can report it, instead of the process
+    crashing on a late/duplicate response the way the synchronous version
+    could when a client had already timed out and cancelled the request.
+    """
+    global db
+
+    try:
+        config = load_config()
+        status_info = get_export_status(config, export_id)
+        parquet_urls = status_info["parquetFiles"]
+
+        _set_job(export_id, state="downloading", files_total=len(parquet_urls), files_done=0)
+        print(f"Downloading {len(parquet_urls)} {export_type} files...", file=sys.stderr)
+        file_data = download_all_files(parquet_urls, config["api_key"])
+        _set_job(export_id, files_done=len(parquet_urls))
+
+        _set_job(export_id, state="loading")
+
+        temp_dir = tempfile.mkdtemp()
+        validation_warnings = []
+
+        try:
+            with _db_lock:
+                if db is None:
+                    initialize_database()
+
+                result_list = status_info.get("result") or []
+
+                url_to_prefix = {}
+                for item in result_list:
+                    prefix = item.get("prefix", "")
+                    for url in item.get("urls", []):
+                        url_to_prefix[url] = prefix
+
+                prefix_file_map = {}
+                for i, (url, data) in enumerate(zip(parquet_urls, file_data)):
+                    temp_path = Path(temp_dir) / f"{export_type}_export_{i}.parquet"
+                    temp_path.write_bytes(data)
+                    prefix = url_to_prefix.get(url, "unknown")
+                    prefix_file_map.setdefault(prefix, []).append(str(temp_path))
+                    if len(data) < 100:
+                        validation_warnings.append(
+                            f"File {i + 1} (prefix={prefix}): unusually small ({len(data)} bytes)"
+                        )
+
+                if export_type == "policy":
+                    row_counts = db.load_parquet_files_by_prefix(prefix_file_map, skip_prefixes={"asset"})
+                elif export_type == "remediation":
+                    row_counts = db.load_parquet_files_by_prefix(prefix_file_map, append=True)
+                else:
+                    row_counts = db.load_parquet_files_by_prefix(prefix_file_map)
+
+                row_count = sum(row_counts.values())
+                row_info = f"Rows loaded: {row_count}\nPer-table row counts: {json.dumps(row_counts, default=str)}"
+
+                if row_count == 0 and len(file_data) > 0:
+                    validation_warnings.append(
+                        f"⚠️  {len(file_data)} file(s) downloaded but 0 rows loaded. "
+                        f"Prefixes received: {list(prefix_file_map.keys())}. "
+                        f"Check that prefixes match expected routing."
+                    )
+
+                tracker = ExportTracker(str(_DATA_DIR / "rapid7_bulk_export_tracking.db"))
+                tracker.save_export(
+                    export_id=export_id,
+                    status="COMPLETE",
+                    parquet_urls=parquet_urls,
+                    row_count=row_count,
+                    export_type=export_type,
+                )
+                tracker.close()
+
+                stats = db.get_stats()
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+        warnings_section = ""
+        if validation_warnings:
+            warnings_section = "\nValidation Warnings:\n" + "\n".join(f"  {w}" for w in validation_warnings) + "\n"
+
+        message = (
+            f"✓ {export_type.capitalize()} data loaded successfully.\n\n"
+            f"Export ID: {export_id}\n"
+            f"Files processed: {len(parquet_urls)}\n"
+            f"{row_info}\n"
+            f"{warnings_section}\n"
+            f"Statistics:\n"
+            f"{json.dumps(stats, indent=2, default=str)}\n\n"
+            f"Query the data with query_rapid7, get_rapid7_schema, or get_rapid7_stats."
+        )
+        _set_job(export_id, state="complete", message=message, error=None)
+
+    except Exception as e:
+        error_text = f"{e}\n{traceback.format_exc()}"
+        message = (
+            f"✗ Error downloading/loading {export_type}: {str(e)}\n\n"
+            f"Export ID: {export_id}\n"
+            f"Retry with: download_rapid7_export("
+            f'export_id="{export_id}", '
+            f'export_type="{export_type}")'
+        )
+        _set_job(export_id, state="failed", message=message, error=error_text)
+
+
 @mcp.tool(
     annotations=ToolAnnotations(
         title="Download Rapid7 Export",
@@ -374,29 +535,30 @@ def check_rapid7_export_status(export_id: str) -> str:
     )
 )
 def download_rapid7_export(export_id: str, export_type: str = "vulnerability") -> str:
-    """Download a completed Rapid7 export and load into the database.
+    """Start downloading a completed Rapid7 export and loading it into the database.
 
     Call this after check_rapid7_export_status confirms the export is COMPLETE.
-    Downloads the Parquet files and loads them into the local DuckDB
-    database for querying.
+    This kicks off the download and load in the background and returns
+    immediately — large exports (potentially millions of rows) can take
+    several minutes to load, longer than most MCP clients will wait on a
+    single tool call. Poll progress with check_download_status(export_id).
 
     Args:
         export_id: The export ID of a completed export.
         export_type: Type of export. One of "vulnerability", "policy",
-                     or "remediation".
+                     "remediation", or "asset_software".
 
     Returns:
-        Summary of loaded data including row counts and statistics.
+        Confirmation that the background job has started, plus how to
+        check on it.
     """
-    global db
-
     if export_type not in VALID_EXPORT_TYPES:
         return f"✗ Invalid export_type: '{export_type}'. Valid values are: {', '.join(VALID_EXPORT_TYPES)}"
 
     try:
         config = load_config()
 
-        # Verify export is complete
+        # Quick call — just confirms the export is ready, doesn't download anything.
         status_info = get_export_status(config, export_id)
         current_status = status_info["status"]
 
@@ -410,101 +572,111 @@ def download_rapid7_export(export_id: str, export_type: str = "vulnerability") -
                 f'export_id="{export_id}")'
             )
 
-        parquet_urls = status_info["parquetFiles"]
-        if not parquet_urls:
+        if not status_info["parquetFiles"]:
             return f"✗ Export complete but has no files.\n\nExport ID: {export_id}"
 
-        # Download files
-        print(f"Downloading {len(parquet_urls)} {export_type} files...", file=sys.stderr)
-        file_data = download_all_files(parquet_urls, config["api_key"])
-
-        # Initialize database if needed
-        if db is None:
-            initialize_database()
-
-        temp_dir = tempfile.mkdtemp()
-        validation_warnings = []
-
-        try:
-            # All export types use prefix-based routing from the API response
-            result_list = status_info.get("result") or []
-
-            url_to_prefix = {}
-            for item in result_list:
-                prefix = item.get("prefix", "")
-                for url in item.get("urls", []):
-                    url_to_prefix[url] = prefix
-
-            prefix_file_map = {}
-            for i, (url, data) in enumerate(zip(parquet_urls, file_data)):
-                temp_path = Path(temp_dir) / f"{export_type}_export_{i}.parquet"
-                temp_path.write_bytes(data)
-                prefix = url_to_prefix.get(url, "unknown")
-                prefix_file_map.setdefault(prefix, []).append(str(temp_path))
-                # Validate file has content
-                if len(data) < 100:
-                    validation_warnings.append(f"File {i + 1} (prefix={prefix}): unusually small ({len(data)} bytes)")
-
-            if export_type == "policy":
-                row_counts = db.load_parquet_files_by_prefix(prefix_file_map, skip_prefixes={"asset"})
-            elif export_type == "remediation":
-                row_counts = db.load_parquet_files_by_prefix(prefix_file_map, append=True)
-            else:
-                row_counts = db.load_parquet_files_by_prefix(prefix_file_map)
-
-            row_count = sum(row_counts.values())
-            row_info = f"Rows loaded: {row_count}\nPer-table row counts: {json.dumps(row_counts, default=str)}"
-
-            if row_count == 0 and len(file_data) > 0:
-                validation_warnings.append(
-                    f"⚠️  {len(file_data)} file(s) downloaded but 0 rows loaded. "
-                    f"Prefixes received: {list(prefix_file_map.keys())}. "
-                    f"Check that prefixes match expected routing."
-                )
-
-            # Save export metadata
-            tracker = ExportTracker(str(_DATA_DIR / "rapid7_bulk_export_tracking.db"))
-            tracker.save_export(
-                export_id=export_id,
-                status="COMPLETE",
-                parquet_urls=parquet_urls,
-                row_count=row_count,
-                export_type=export_type,
+        # Don't start a second job for the same export if one's already running.
+        existing = _get_job(export_id)
+        if existing is not None and existing.get("state") in ("downloading", "loading"):
+            return (
+                f"⏳ A download for this export is already in progress "
+                f"(state: {existing['state']}).\n\n"
+                f"Export ID: {export_id}\n"
+                f'Check progress with: check_download_status(export_id="{export_id}")'
             )
-            tracker.close()
 
-            # Get statistics
-            stats = db.get_stats()
+        _set_job(
+            export_id,
+            state="queued",
+            export_type=export_type,
+            message=None,
+            error=None,
+            started_at=_dt.datetime.now().isoformat(timespec="seconds"),
+        )
 
-        finally:
-            # Clean up temp files
-            shutil.rmtree(temp_dir)
-
-        # Build validation warnings section
-        warnings_section = ""
-        if validation_warnings:
-            warnings_section = "\nValidation Warnings:\n" + "\n".join(f"  {w}" for w in validation_warnings) + "\n"
+        thread = threading.Thread(
+            target=_run_download_and_load,
+            args=(export_id, export_type),
+            daemon=True,
+        )
+        thread.start()
 
         return (
-            f"✓ {export_type.capitalize()} data loaded successfully.\n\n"
+            f"▶️ Started downloading and loading {export_type} export in the background.\n\n"
             f"Export ID: {export_id}\n"
-            f"Files processed: {len(parquet_urls)}\n"
-            f"{row_info}\n"
-            f"{warnings_section}\n"
-            f"Statistics:\n"
-            f"{json.dumps(stats, indent=2, default=str)}\n\n"
-            f"Query the data with query_rapid7, "
-            f"get_rapid7_schema, or get_rapid7_stats."
+            f"Files: {len(status_info['parquetFiles'])}\n\n"
+            f"This can take several minutes for large exports. Check progress with:\n"
+            f'check_download_status(export_id="{export_id}")'
         )
 
     except Exception as e:
         return (
-            f"✗ Error downloading/loading {export_type}: {str(e)}\n\n"
+            f"✗ Error starting download for {export_type}: {str(e)}\n\n"
             f"Export ID: {export_id}\n"
             f"Retry with: download_rapid7_export("
             f'export_id="{export_id}", '
             f'export_type="{export_type}")'
         )
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Check Rapid7 Download Status",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    )
+)
+def check_download_status(export_id: str) -> str:
+    """Check the status of a background download/load job started by download_rapid7_export.
+
+    This is a fast, non-blocking call — it just reports the current state
+    of the in-memory job tracker. Does not wait for the job to finish.
+
+    Args:
+        export_id: The export ID passed to download_rapid7_export.
+
+    Returns:
+        Current job state, and full results/statistics once complete.
+    """
+    job = _get_job(export_id)
+
+    if job is None:
+        return (
+            f"No background download job found for export ID: {export_id}\n\n"
+            f"Either it hasn't been started yet (start with download_rapid7_export), "
+            f"or the server process was restarted since it ran — job tracking is "
+            f"in-memory only and does not survive a restart. If you believe the data "
+            f"already loaded successfully before a restart, try get_rapid7_stats() "
+            f"directly to check."
+        )
+
+    state = job.get("state")
+
+    if state == "complete":
+        return job.get("message", "✓ Load completed, but no summary message was recorded.")
+
+    if state == "failed":
+        return job.get("message", "✗ Load failed, but no error message was recorded.")
+
+    if state in ("queued", "downloading", "loading"):
+        files_total = job.get("files_total")
+        files_done = job.get("files_done")
+        progress = ""
+        if files_total:
+            progress = f"\nFiles downloaded: {files_done or 0} / {files_total}"
+
+        return (
+            f"⏳ Job is {state}.\n\n"
+            f"Export ID: {export_id}\n"
+            f"Started: {job.get('started_at', 'unknown')}\n"
+            f"Last update: {job.get('updated_at', 'unknown')}{progress}\n\n"
+            f"Check again in 30-60 seconds with: "
+            f'check_download_status(export_id="{export_id}")'
+        )
+
+    return f"Unknown job state '{state}' for export ID: {export_id}"
 
 
 @mcp.tool(
@@ -571,12 +743,20 @@ def query_rapid7(sql: str) -> str:
     if db is None or not db.has_data():
         return "Error: No data loaded. Please run start_rapid7_export and download_rapid7_export first."
 
+    if not _db_lock.acquire(blocking=False):
+        return (
+            "⏳ A background download/load is currently in progress, so the "
+            "database can't be safely queried right now. Try again shortly, "
+            "or check check_download_status(export_id=...) for progress."
+        )
     try:
         results = db.query(sql)
         result_text = json.dumps(results, indent=2, default=str)
         return f"Query executed successfully. {len(results)} rows returned.\n\n{result_text}"
     except Exception as e:
         return f"Error executing query: {str(e)}"
+    finally:
+        _db_lock.release()
 
 
 @mcp.tool(
@@ -605,12 +785,20 @@ def get_rapid7_schema() -> str:
     if db is None or not db.has_data():
         return "Error: No data loaded. Please run start_rapid7_export and download_rapid7_export first."
 
+    if not _db_lock.acquire(blocking=False):
+        return (
+            "⏳ A background download/load is currently in progress, so the "
+            "schema can't be safely read right now. Try again shortly, or "
+            "check check_download_status(export_id=...) for progress."
+        )
     try:
         schema = db.get_schema()
         schema_text = json.dumps(schema, indent=2)
         return f"Database schema:\n\n{schema_text}"
     except Exception as e:
         return f"Error getting schema: {str(e)}"
+    finally:
+        _db_lock.release()
 
 
 @mcp.tool(
@@ -639,12 +827,20 @@ def get_rapid7_stats() -> str:
     if db is None or not db.has_data():
         return "Error: No data loaded. Please run start_rapid7_export and download_rapid7_export first."
 
+    if not _db_lock.acquire(blocking=False):
+        return (
+            "⏳ A background download/load is currently in progress, so "
+            "statistics can't be safely read right now. Try again shortly, "
+            "or check check_download_status(export_id=...) for progress."
+        )
     try:
         stats = db.get_stats()
         stats_text = json.dumps(stats, indent=2, default=str)
         return f"Database statistics:\n\n{stats_text}"
     except Exception as e:
         return f"Error getting statistics: {str(e)}"
+    finally:
+        _db_lock.release()
 
 
 @mcp.tool(

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -16,7 +16,7 @@ import tempfile
 import threading
 import traceback
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import duckdb as _duckdb
 from fastmcp import FastMCP
@@ -61,31 +61,34 @@ VALID_EXPORT_TYPES = ("vulnerability", "policy", "remediation", "asset_software"
 #
 # To avoid this, download_rapid7_export() only *starts* the work in a
 # background thread and returns immediately. Progress and results are
-# tracked here and can be polled with check_download_status().
+# recorded as phase transitions on the durable ExportTracker row (not an
+# in-memory dict), so state survives a server restart and is reported by
+# the existing check_rapid7_export_status() and list_rapid7_exports()
+# tools — there is no separate status tool to poll.
 # ---------------------------------------------------------------------------
 
-# export_id -> job info dict. Guarded by _jobs_lock.
-_download_jobs: Dict[str, Dict[str, Any]] = {}
-_jobs_lock = threading.Lock()
+# Local load-phase values written to the tracker's `status` column. These
+# describe THIS server's download+load progress, distinct from the Rapid7
+# platform-side export status returned by the API (PENDING/PROCESSING/…).
+PHASE_DOWNLOADING = "DOWNLOADING"
+PHASE_LOADING = "LOADING"
+PHASE_COMPLETE = "COMPLETE"  # data loaded locally and queryable
+PHASE_FAILED = "FAILED"
+
+# States that mean a background load is actively touching the database, so a
+# second download must not start and reads should back off.
+_ACTIVE_PHASES = (PHASE_DOWNLOADING, PHASE_LOADING)
 
 # Guards all access to the shared `db` connection (both the background
 # load and the read tools below) so a query can never run concurrently
-# with a table being dropped/recreated mid-load.
-_db_lock = threading.Lock()
+# with a table being dropped/recreated mid-load. Re-entrant so a locked
+# section can safely call another helper that also acquires it.
+_db_lock = threading.RLock()
 
 
-def _set_job(export_id: str, **fields: Any) -> None:
-    """Create or update a job's tracked state."""
-    with _jobs_lock:
-        job = _download_jobs.setdefault(export_id, {})
-        job.update(fields)
-        job["updated_at"] = _dt.datetime.now().isoformat(timespec="seconds")
-
-
-def _get_job(export_id: str) -> Optional[Dict[str, Any]]:
-    with _jobs_lock:
-        job = _download_jobs.get(export_id)
-        return dict(job) if job is not None else None
+def _tracker() -> ExportTracker:
+    """Open a tracker handle on the standard tracking database."""
+    return ExportTracker(str(_DATA_DIR / "rapid7_bulk_export_tracking.db"))
 
 
 def initialize_database(db_path: Optional[str] = None) -> VulnerabilityDatabase:
@@ -151,7 +154,7 @@ def load_rapid7_parquet(parquet_path: str) -> str:
             return (
                 "⏳ A background download/load is currently in progress. "
                 "Try again shortly, or check "
-                "check_download_status(export_id=...) for progress."
+                "check_rapid7_export_status(export_id=...) for progress."
             )
         try:
             # Initialize database if needed
@@ -366,18 +369,57 @@ def start_rapid7_export(
     )
 )
 def check_rapid7_export_status(export_id: str) -> str:
-    """Check the current status of a Rapid7 export job.
+    """Check the status of a Rapid7 export, including local download/load progress.
 
-    This is a fast, non-blocking call that queries the Rapid7 API once
-    and returns the current status. Does NOT poll or wait.
+    Fast, non-blocking call. Reports whichever stage the export is in:
+
+      - While this server is downloading or loading the export in the
+        background, reports that local phase and per-file progress — and
+        skips the Rapid7 API call, since the platform-side export is
+        already known to be complete.
+      - Once loaded (COMPLETE) or failed (FAILED) locally, returns the
+        stored summary/error so no work is repeated.
+      - Otherwise queries the Rapid7 API once for the platform-side export
+        status (PENDING/PROCESSING/COMPLETE/FAILED).
+
+    Because local phase lives in the durable tracker, it survives a server
+    restart. Does NOT poll or wait.
 
     Args:
         export_id: The export ID returned by start_rapid7_export.
 
     Returns:
-        Current export status and next steps.
+        Current export/load status and next steps.
     """
     try:
+        # Local load phase takes precedence: if a background download/load is
+        # active or has reached a terminal state, report that and skip the
+        # (now-redundant) platform-side status call.
+        tracker = _tracker()
+        local = tracker.get_export_by_id(export_id)
+        tracker.close()
+
+        if local is not None:
+            local_status = local.get("status")
+
+            if local_status == PHASE_COMPLETE:
+                return local.get("message") or (
+                    f"✓ Data loaded and queryable.\n\nExport ID: {export_id}\nRows: {local.get('row_count')}"
+                )
+            if local_status == PHASE_FAILED:
+                return local.get("message") or f"✗ Download/load failed.\n\nExport ID: {export_id}"
+            if local_status in _ACTIVE_PHASES:
+                detail = local.get("phase_detail")
+                detail_line = f"\n{detail}" if detail else ""
+                return (
+                    f"⏳ Downloading/loading in progress locally ({local_status}).{detail_line}\n\n"
+                    f"Export ID: {export_id}\n"
+                    f"Last update: {local.get('created_at', 'unknown')}\n\n"
+                    f"Check again in 30-60 seconds with: "
+                    f'check_rapid7_export_status(export_id="{export_id}")'
+                )
+            # PENDING or any other value falls through to the platform-side check.
+
         config = load_config()
         status_info = get_export_status(config, export_id)
         current_status = status_info["status"]
@@ -385,7 +427,7 @@ def check_rapid7_export_status(export_id: str) -> str:
 
         if current_status in ["COMPLETE", "SUCCEEDED"]:
             return (
-                f"✓ Export is complete.\n\n"
+                f"✓ Export is complete on Rapid7's side and ready to download.\n\n"
                 f"Export ID: {export_id}\n"
                 f"Status: {current_status}\n"
                 f"Files ready: {file_count}\n\n"
@@ -418,26 +460,35 @@ def check_rapid7_export_status(export_id: str) -> str:
 def _run_download_and_load(export_id: str, export_type: str) -> None:
     """Background worker: download parquet files and load them into DuckDB.
 
-    Runs in its own thread. All progress/results are written to
-    _download_jobs[export_id] rather than returned, since nothing is
-    waiting on a function return here. Any exception is caught and stored
-    so check_download_status() can report it, instead of the process
-    crashing on a late/duplicate response the way the synchronous version
-    could when a client had already timed out and cancelled the request.
+    Runs in its own thread. All progress/results are written to the
+    ExportTracker row for this export_id rather than returned, since
+    nothing is waiting on a function return here. Any exception is caught
+    and recorded as a FAILED phase (with the error text) so the status
+    tools can report it, instead of the process crashing on a late/
+    duplicate response the way the synchronous version could when a client
+    had already timed out and cancelled the request.
     """
     global db
 
+    tracker = _tracker()
     try:
         config = load_config()
         status_info = get_export_status(config, export_id)
         parquet_urls = status_info["parquetFiles"]
 
-        _set_job(export_id, state="downloading", files_total=len(parquet_urls), files_done=0)
+        tracker.set_phase(
+            export_id,
+            PHASE_DOWNLOADING,
+            phase_detail=f"0 / {len(parquet_urls)} files downloaded",
+        )
         print(f"Downloading {len(parquet_urls)} {export_type} files...", file=sys.stderr)
         file_data = download_all_files(parquet_urls, config["api_key"])
-        _set_job(export_id, files_done=len(parquet_urls))
 
-        _set_job(export_id, state="loading")
+        tracker.set_phase(
+            export_id,
+            PHASE_LOADING,
+            phase_detail=f"{len(parquet_urls)} / {len(parquet_urls)} files downloaded, loading into database",
+        )
 
         temp_dir = tempfile.mkdtemp()
         validation_warnings = []
@@ -483,16 +534,6 @@ def _run_download_and_load(export_id: str, export_type: str) -> None:
                         f"Check that prefixes match expected routing."
                     )
 
-                tracker = ExportTracker(str(_DATA_DIR / "rapid7_bulk_export_tracking.db"))
-                tracker.save_export(
-                    export_id=export_id,
-                    status="COMPLETE",
-                    parquet_urls=parquet_urls,
-                    row_count=row_count,
-                    export_type=export_type,
-                )
-                tracker.close()
-
                 stats = db.get_stats()
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
@@ -511,7 +552,15 @@ def _run_download_and_load(export_id: str, export_type: str) -> None:
             f"{json.dumps(stats, indent=2, default=str)}\n\n"
             f"Query the data with query_rapid7, get_rapid7_schema, or get_rapid7_stats."
         )
-        _set_job(export_id, state="complete", message=message, error=None)
+        # Record the completed load with its parquet URLs and final row count.
+        tracker.save_export(
+            export_id=export_id,
+            status=PHASE_COMPLETE,
+            parquet_urls=parquet_urls,
+            row_count=row_count,
+            export_type=export_type,
+        )
+        tracker.set_phase(export_id, PHASE_COMPLETE, phase_detail=None, message=message, row_count=row_count)
 
     except Exception as e:
         error_text = f"{e}\n{traceback.format_exc()}"
@@ -520,9 +569,12 @@ def _run_download_and_load(export_id: str, export_type: str) -> None:
             f"Export ID: {export_id}\n"
             f"Retry with: download_rapid7_export("
             f'export_id="{export_id}", '
-            f'export_type="{export_type}")'
+            f'export_type="{export_type}")\n\n'
+            f"{error_text}"
         )
-        _set_job(export_id, state="failed", message=message, error=error_text)
+        tracker.set_phase(export_id, PHASE_FAILED, phase_detail=None, message=message)
+    finally:
+        tracker.close()
 
 
 @mcp.tool(
@@ -541,7 +593,7 @@ def download_rapid7_export(export_id: str, export_type: str = "vulnerability") -
     This kicks off the download and load in the background and returns
     immediately — large exports (potentially millions of rows) can take
     several minutes to load, longer than most MCP clients will wait on a
-    single tool call. Poll progress with check_download_status(export_id).
+    single tool call. Poll progress with check_rapid7_export_status(export_id).
 
     Args:
         export_id: The export ID of a completed export.
@@ -576,23 +628,33 @@ def download_rapid7_export(export_id: str, export_type: str = "vulnerability") -
             return f"✗ Export complete but has no files.\n\nExport ID: {export_id}"
 
         # Don't start a second job for the same export if one's already running.
-        existing = _get_job(export_id)
-        if existing is not None and existing.get("state") in ("downloading", "loading"):
+        tracker = _tracker()
+        existing = tracker.get_export_by_id(export_id)
+        if existing is not None and existing.get("status") in _ACTIVE_PHASES:
+            tracker.close()
             return (
                 f"⏳ A download for this export is already in progress "
-                f"(state: {existing['state']}).\n\n"
+                f"(status: {existing['status']}).\n\n"
                 f"Export ID: {export_id}\n"
-                f'Check progress with: check_download_status(export_id="{export_id}")'
+                f'Check progress with: check_rapid7_export_status(export_id="{export_id}")'
             )
 
-        _set_job(
-            export_id,
-            state="queued",
+        # Record the initial phase durably. The row usually already exists at
+        # PENDING (start_rapid7_export inserts it); save_export upserts so a
+        # directly-supplied export_id is tracked too.
+        parquet_urls = status_info["parquetFiles"]
+        tracker.save_export(
+            export_id=export_id,
+            status=PHASE_DOWNLOADING,
+            parquet_urls=parquet_urls,
             export_type=export_type,
-            message=None,
-            error=None,
-            started_at=_dt.datetime.now().isoformat(timespec="seconds"),
         )
+        tracker.set_phase(
+            export_id,
+            PHASE_DOWNLOADING,
+            phase_detail=f"0 / {len(parquet_urls)} files downloaded",
+        )
+        tracker.close()
 
         thread = threading.Thread(
             target=_run_download_and_load,
@@ -604,9 +666,9 @@ def download_rapid7_export(export_id: str, export_type: str = "vulnerability") -
         return (
             f"▶️ Started downloading and loading {export_type} export in the background.\n\n"
             f"Export ID: {export_id}\n"
-            f"Files: {len(status_info['parquetFiles'])}\n\n"
+            f"Files: {len(parquet_urls)}\n\n"
             f"This can take several minutes for large exports. Check progress with:\n"
-            f'check_download_status(export_id="{export_id}")'
+            f'check_rapid7_export_status(export_id="{export_id}")'
         )
 
     except Exception as e:
@@ -617,66 +679,6 @@ def download_rapid7_export(export_id: str, export_type: str = "vulnerability") -
             f'export_id="{export_id}", '
             f'export_type="{export_type}")'
         )
-
-
-@mcp.tool(
-    annotations=ToolAnnotations(
-        title="Check Rapid7 Download Status",
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    )
-)
-def check_download_status(export_id: str) -> str:
-    """Check the status of a background download/load job started by download_rapid7_export.
-
-    This is a fast, non-blocking call — it just reports the current state
-    of the in-memory job tracker. Does not wait for the job to finish.
-
-    Args:
-        export_id: The export ID passed to download_rapid7_export.
-
-    Returns:
-        Current job state, and full results/statistics once complete.
-    """
-    job = _get_job(export_id)
-
-    if job is None:
-        return (
-            f"No background download job found for export ID: {export_id}\n\n"
-            f"Either it hasn't been started yet (start with download_rapid7_export), "
-            f"or the server process was restarted since it ran — job tracking is "
-            f"in-memory only and does not survive a restart. If you believe the data "
-            f"already loaded successfully before a restart, try get_rapid7_stats() "
-            f"directly to check."
-        )
-
-    state = job.get("state")
-
-    if state == "complete":
-        return job.get("message", "✓ Load completed, but no summary message was recorded.")
-
-    if state == "failed":
-        return job.get("message", "✗ Load failed, but no error message was recorded.")
-
-    if state in ("queued", "downloading", "loading"):
-        files_total = job.get("files_total")
-        files_done = job.get("files_done")
-        progress = ""
-        if files_total:
-            progress = f"\nFiles downloaded: {files_done or 0} / {files_total}"
-
-        return (
-            f"⏳ Job is {state}.\n\n"
-            f"Export ID: {export_id}\n"
-            f"Started: {job.get('started_at', 'unknown')}\n"
-            f"Last update: {job.get('updated_at', 'unknown')}{progress}\n\n"
-            f"Check again in 30-60 seconds with: "
-            f'check_download_status(export_id="{export_id}")'
-        )
-
-    return f"Unknown job state '{state}' for export ID: {export_id}"
 
 
 @mcp.tool(
@@ -747,7 +749,7 @@ def query_rapid7(sql: str) -> str:
         return (
             "⏳ A background download/load is currently in progress, so the "
             "database can't be safely queried right now. Try again shortly, "
-            "or check check_download_status(export_id=...) for progress."
+            "or check check_rapid7_export_status(export_id=...) for progress."
         )
     try:
         results = db.query(sql)
@@ -789,7 +791,7 @@ def get_rapid7_schema() -> str:
         return (
             "⏳ A background download/load is currently in progress, so the "
             "schema can't be safely read right now. Try again shortly, or "
-            "check check_download_status(export_id=...) for progress."
+            "check check_rapid7_export_status(export_id=...) for progress."
         )
     try:
         schema = db.get_schema()
@@ -831,7 +833,7 @@ def get_rapid7_stats() -> str:
         return (
             "⏳ A background download/load is currently in progress, so "
             "statistics can't be safely read right now. Try again shortly, "
-            "or check check_download_status(export_id=...) for progress."
+            "or check check_rapid7_export_status(export_id=...) for progress."
         )
     try:
         stats = db.get_stats()
@@ -869,12 +871,21 @@ def purge_rapid7_data() -> str:
     """
     global db
 
+    # Refuse to purge while a background load holds the database — dropping the
+    # file mid-load would corrupt the in-flight load and leave stale tracker
+    # rows. Non-blocking to match the read tools.
+    if not _db_lock.acquire(blocking=False):
+        return (
+            "⏳ A background download/load is currently in progress, so the "
+            "database can't be purged right now. Try again once it finishes "
+            "(check_rapid7_export_status(export_id=...) shows progress)."
+        )
     try:
         # Purge main database
         if db is not None:
             db.purge()
 
-        # Purge tracking database
+        # Purge tracking database (also clears all export/phase rows)
         tracker = ExportTracker(str(_DATA_DIR / "rapid7_bulk_export_tracking.db"))
         tracker.purge()
 
@@ -888,6 +899,8 @@ def purge_rapid7_data() -> str:
 
     except Exception as e:
         return f"✗ Error purging data: {str(e)}"
+    finally:
+        _db_lock.release()
 
 
 @mcp.tool(
@@ -912,6 +925,9 @@ def list_rapid7_exports(limit: int = 10) -> str:
         Formatted list of recent exports
     """
     try:
+        # Reads only the local tracker DB (not the shared query database), so
+        # it needs no _db_lock guard and is safe to call during a load — that
+        # is in fact how you watch a background load progress.
         tracker = ExportTracker(str(_DATA_DIR / "rapid7_bulk_export_tracking.db"))
         exports = tracker.list_exports(limit=limit)
         tracker.close()
@@ -926,6 +942,8 @@ def list_rapid7_exports(limit: int = 10) -> str:
             result += f"  Date: {exp['export_date']}\n"
             result += f"  Created: {exp['created_at']}\n"
             result += f"  Status: {exp['status']}\n"
+            if exp.get("phase_detail"):
+                result += f"  Progress: {exp['phase_detail']}\n"
             result += f"  Files: {exp['file_count']}\n"
             result += f"  Rows: {exp['row_count']}\n\n"
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -329,6 +329,28 @@ def start_rapid7_export(
             if not end_date:
                 end_date = _dt.date.today().isoformat()
 
+            # Idempotency: this MCP tool may be retried. A remediation job
+            # appends its windows, so starting a second job for the SAME range
+            # would double the rows. Reuse an existing job for the exact range —
+            # report progress if it's still RUNNING, or its stored result if
+            # COMPLETE — and only start a fresh job when none exists or the
+            # prior one FAILED (an intended retry).
+            existing = tracker.find_job_by_range("remediation", start_date, end_date)
+            if existing is not None and existing.get("status") in (JOB_RUNNING, JOB_COMPLETE):
+                tracker.close()
+                jid = existing["job_id"]
+                if existing["status"] == JOB_COMPLETE:
+                    return (
+                        f"♻️ Remediation data for {start_date} → {end_date} is already loaded "
+                        f"(job {jid}). Not re-running (that would duplicate rows).\n\n"
+                        f'See results with: check_rapid7_export_status(export_id="{jid}")'
+                    )
+                return (
+                    f"⏳ A remediation load for {start_date} → {end_date} is already in progress "
+                    f"(job {jid}).\n\n"
+                    f'Check progress with: check_rapid7_export_status(export_id="{jid}")'
+                )
+
             # A remediation range may span multiple ≤31-day windows, and the
             # platform allows only one remediation export in flight at a time.
             # Hand the whole range to a single background job that creates,

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -66,9 +66,10 @@ VALID_EXPORT_TYPES = ("vulnerability", "policy", "remediation", "asset_software"
 # To avoid this, download_rapid7_export() only *starts* the work in a
 # background thread and returns immediately. Progress and results are
 # recorded as phase transitions on the durable ExportTracker row (not an
-# in-memory dict), so state survives a server restart and is reported by
-# the existing check_rapid7_export_status() and list_rapid7_exports()
-# tools — there is no separate status tool to poll.
+# in-memory dict), so state is durable and inspectable after a restart and is
+# reported by the existing check_rapid7_export_status() and list_rapid7_exports()
+# tools — there is no separate status tool to poll. Workers do not resume across
+# a restart; interrupted work is reconciled to a retryable FAILED at startup.
 # ---------------------------------------------------------------------------
 
 # Local load-phase values written to the tracker's `status` column. These
@@ -393,8 +394,9 @@ def check_rapid7_export_status(export_id: str) -> str:
       - Otherwise queries the Rapid7 API once for the platform-side export
         status (PENDING/PROCESSING/COMPLETE/FAILED).
 
-    Because local phase lives in the durable tracker, it survives a server
-    restart. Does NOT poll or wait.
+    Because local phase lives in the durable tracker, it is inspectable after
+    a server restart (interrupted work is reconciled to a retryable FAILED at
+    startup rather than resumed). Does NOT poll or wait.
 
     Args:
         export_id: The export ID returned by start_rapid7_export, or a
@@ -433,7 +435,7 @@ def check_rapid7_export_status(export_id: str) -> str:
                 return (
                     f"⏳ Downloading/loading in progress locally ({local_status}).{detail_line}\n\n"
                     f"Export ID: {export_id}\n"
-                    f"Last update: {local.get('created_at', 'unknown')}\n\n"
+                    f"Last update: {local.get('updated_at') or local.get('created_at', 'unknown')}\n\n"
                     f"Check again in 30-60 seconds with: "
                     f'check_rapid7_export_status(export_id="{export_id}")'
                 )
@@ -480,18 +482,23 @@ def _download_and_load_files(
     export_type: str,
     status_info: dict,
     api_key: str,
+    on_downloaded=None,
 ) -> tuple:
     """Download an export's parquet files and load them into DuckDB.
 
     Shared by the single-export worker and the multi-chunk remediation
     orchestrator so the download/route/load path is not forked. Acquires
-    _db_lock around the load. Returns (row_count, row_counts, stats,
-    validation_warnings).
+    _db_lock around the load. If provided, on_downloaded() is called once
+    the files are actually downloaded and before the load begins, so a
+    caller can record the LOADING phase honestly. Returns (row_count,
+    row_counts, stats, validation_warnings).
     """
     global db
 
     parquet_urls = status_info["parquetFiles"]
     file_data = download_all_files(parquet_urls, api_key)
+    if on_downloaded is not None:
+        on_downloaded()
 
     temp_dir = tempfile.mkdtemp()
     validation_warnings: list = []
@@ -558,18 +565,19 @@ def _run_download_and_load(export_id: str, export_type: str) -> None:
         tracker.set_phase(
             export_id,
             PHASE_DOWNLOADING,
-            phase_detail=f"0 / {len(parquet_urls)} files downloaded",
+            phase_detail=f"downloading {len(parquet_urls)} file(s)",
         )
         print(f"Downloading {len(parquet_urls)} {export_type} files...", file=sys.stderr)
 
-        tracker.set_phase(
-            export_id,
-            PHASE_LOADING,
-            phase_detail=f"{len(parquet_urls)} files downloaded, loading into database",
-        )
+        def _mark_loading() -> None:
+            tracker.set_phase(
+                export_id,
+                PHASE_LOADING,
+                phase_detail=f"{len(parquet_urls)} file(s) downloaded, loading into database",
+            )
 
         row_count, row_counts, stats, validation_warnings = _download_and_load_files(
-            export_type, status_info, config["api_key"]
+            export_type, status_info, config["api_key"], on_downloaded=_mark_loading
         )
         row_info = f"Rows loaded: {row_count}\nPer-table row counts: {json.dumps(row_counts, default=str)}"
 
@@ -672,10 +680,16 @@ def _run_remediation_job(job_id: str, chunks: list) -> None:
             if not parquet_urls:
                 status_info["parquetFiles"] = status_info.get("parquetFiles", [])
 
-            _mark("loading")
-            row_count, _, _, _ = _download_and_load_files("remediation", status_info, config["api_key"])
+            row_count, _, _, _ = _download_and_load_files(
+                "remediation", status_info, config["api_key"], on_downloaded=lambda: _mark("loading")
+            )
+            # Mark loaded the instant the append has committed, BEFORE any
+            # further tracker writes. If save_export below throws, the window
+            # is already recorded loaded so the failure report can never tell
+            # the user to re-run a window whose rows are already present.
             total_rows += row_count
             chunks[i]["row_count"] = row_count
+            _mark("loaded")
             tracker.save_export(
                 export_id=eid,
                 status=PHASE_COMPLETE,
@@ -683,7 +697,6 @@ def _run_remediation_job(job_id: str, chunks: list) -> None:
                 row_count=row_count,
                 export_type="remediation",
             )
-            _mark("loaded")
 
         loaded = [f"{c['start']} → {c['end']} ({c.get('row_count', 0)} rows)" for c in chunks]
         message = (
@@ -917,9 +930,9 @@ def query_rapid7(sql: str) -> str:
     """
     global db
 
-    if db is None or not db.has_data():
-        return "Error: No data loaded. Please run start_rapid7_export and download_rapid7_export first."
-
+    # Acquire the lock BEFORE touching db at all — has_data() opens its own
+    # DuckDB connection, which conflicts with a background load's read-write
+    # connection. Locking first turns that into a clean busy response.
     if not _db_lock.acquire(blocking=False):
         return (
             "⏳ A background download/load is currently in progress, so the "
@@ -927,6 +940,8 @@ def query_rapid7(sql: str) -> str:
             "or check check_rapid7_export_status(export_id=...) for progress."
         )
     try:
+        if db is None or not db.has_data():
+            return "Error: No data loaded. Please run start_rapid7_export and download_rapid7_export first."
         results = db.query(sql)
         result_text = json.dumps(results, indent=2, default=str)
         return f"Query executed successfully. {len(results)} rows returned.\n\n{result_text}"
@@ -959,9 +974,6 @@ def get_rapid7_schema() -> str:
     """
     global db
 
-    if db is None or not db.has_data():
-        return "Error: No data loaded. Please run start_rapid7_export and download_rapid7_export first."
-
     if not _db_lock.acquire(blocking=False):
         return (
             "⏳ A background download/load is currently in progress, so the "
@@ -969,6 +981,8 @@ def get_rapid7_schema() -> str:
             "check check_rapid7_export_status(export_id=...) for progress."
         )
     try:
+        if db is None or not db.has_data():
+            return "Error: No data loaded. Please run start_rapid7_export and download_rapid7_export first."
         schema = db.get_schema()
         schema_text = json.dumps(schema, indent=2)
         return f"Database schema:\n\n{schema_text}"
@@ -1001,9 +1015,6 @@ def get_rapid7_stats() -> str:
     """
     global db
 
-    if db is None or not db.has_data():
-        return "Error: No data loaded. Please run start_rapid7_export and download_rapid7_export first."
-
     if not _db_lock.acquire(blocking=False):
         return (
             "⏳ A background download/load is currently in progress, so "
@@ -1011,6 +1022,8 @@ def get_rapid7_stats() -> str:
             "or check check_rapid7_export_status(export_id=...) for progress."
         )
     try:
+        if db is None or not db.has_data():
+            return "Error: No data loaded. Please run start_rapid7_export and download_rapid7_export first."
         stats = db.get_stats()
         stats_text = json.dumps(stats, indent=2, default=str)
         return f"Database statistics:\n\n{stats_text}"
@@ -1056,6 +1069,25 @@ def purge_rapid7_data() -> str:
             "(check_rapid7_export_status(export_id=...) shows progress)."
         )
     try:
+        # Even with the lock, a job can be between windows (downloading/polling)
+        # while the lock is momentarily free. Refuse if any durable export or
+        # job is still active, so a purge can't delete data a worker will then
+        # repopulate under a deleted tracker row.
+        active_tracker = ExportTracker(str(_DATA_DIR / "rapid7_bulk_export_tracking.db"))
+        try:
+            if active_tracker.has_active_work(
+                active_export_statuses=list(_ACTIVE_PHASES),
+                active_job_statuses=[JOB_RUNNING],
+            ):
+                return (
+                    "⏳ A background download/load or multi-window remediation job "
+                    "is still active, so the database can't be purged right now. "
+                    "Wait until check_rapid7_export_status(export_id=...) reports it "
+                    "finished, then purge."
+                )
+        finally:
+            active_tracker.close()
+
         # Purge main database
         if db is not None:
             db.purge()
@@ -1169,6 +1201,20 @@ def main():
     except Exception as e:
         print(f"Warning: Could not initialize database: {e}", file=sys.stderr)
         print("Database will be created when data is loaded.", file=sys.stderr)
+
+    # Reconcile any work left mid-flight by a previous crash/restart. Background
+    # workers are daemon threads with no resume, so a stuck DOWNLOADING/LOADING
+    # export or RUNNING job would otherwise block retry forever.
+    try:
+        recon_tracker = _tracker()
+        recon_tracker.reconcile_interrupted(
+            active_export_statuses=list(_ACTIVE_PHASES),
+            active_job_statuses=[JOB_RUNNING],
+            reason="Interrupted by a server restart before completing. Re-run the export/range to retry.",
+        )
+        recon_tracker.close()
+    except Exception as e:
+        print(f"Warning: could not reconcile interrupted exports: {e}", file=sys.stderr)
 
     # Determine transport mode from environment
     transport = os.environ.get("MCP_TRANSPORT", "stdio")

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -14,7 +14,9 @@ import shutil
 import sys
 import tempfile
 import threading
+import time
 import traceback
+import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -26,12 +28,14 @@ from .config import load_config
 from .download import download_all_files
 from .duckdb_loader import VulnerabilityDatabase
 from .export_manager import (
+    ExportInProgressError,
     build_remediation_date_chunks,
     create_asset_software_export,
     create_policy_export,
     create_remediation_export,
     create_vulnerability_export,
     get_export_status,
+    poll_until_complete,
 )
 from .export_tracker import ExportTracker
 
@@ -78,6 +82,18 @@ PHASE_FAILED = "FAILED"
 # States that mean a background load is actively touching the database, so a
 # second download must not start and reads should back off.
 _ACTIVE_PHASES = (PHASE_DOWNLOADING, PHASE_LOADING)
+
+# Multi-chunk job status values (export_jobs.status). A job spans N per-chunk
+# export IDs; these describe the job as a whole.
+JOB_RUNNING = "RUNNING"
+JOB_COMPLETE = "COMPLETE"
+JOB_FAILED = "FAILED"  # at least one chunk failed; loaded chunks remain
+
+# How long to wait between retries when the platform reports another export of
+# the same type already in flight, and how long to keep retrying before giving
+# up on a chunk.
+_IN_PROGRESS_RETRY_SECS = 30
+_IN_PROGRESS_MAX_WAIT_SECS = 20 * 60
 
 # Guards all access to the shared `db` connection (both the background
 # load and the read tools below) so a query can never run concurrently
@@ -312,31 +328,26 @@ def start_rapid7_export(
             if not end_date:
                 end_date = _dt.date.today().isoformat()
 
-            chunks = build_remediation_date_chunks(start_date, end_date)
-
-            export_ids = []
-            for chunk_start, chunk_end in chunks:
-                print(f"Creating remediation export: {chunk_start} → {chunk_end}", file=sys.stderr)
-                eid = create_remediation_export(config, chunk_start, chunk_end)
-                export_ids.append({"id": eid, "start": chunk_start, "end": chunk_end})
-                tracker.save_export(export_id=eid, status="PENDING", parquet_urls=[], export_type="remediation")
+            # A remediation range may span multiple ≤31-day windows, and the
+            # platform allows only one remediation export in flight at a time.
+            # Hand the whole range to a single background job that creates,
+            # polls, downloads, and loads each window sequentially and appends
+            # them into vulnerability_remediation. The caller polls one job id.
             tracker.close()
+            chunk_ranges = build_remediation_date_chunks(start_date, end_date)
+            job_id = _start_remediation_job(start_date, end_date)
 
-            lines = [
-                f"✓ Created {len(export_ids)} remediation export(s) covering {start_date} → {end_date}.\n",
-            ]
-            for i, info in enumerate(export_ids, 1):
-                lines.append(f"  {i}. {info['start']} → {info['end']}  Export ID: {info['id']}")
-
-            lines.append("")
-            lines.append("Each export takes ~3-5 minutes to process.")
-            lines.append('Check progress with: check_rapid7_export_status(export_id="...")')
-            lines.append(
-                'Once COMPLETE, load each with: download_rapid7_export(export_id="...", export_type="remediation")'
+            return (
+                f"▶️ Started loading remediation data for {start_date} → {end_date} "
+                f"in the background.\n\n"
+                f"Job ID: {job_id}\n"
+                f"Windows: {len(chunk_ranges)} (each ≤31 days, loaded sequentially)\n\n"
+                f"The platform allows only one remediation export at a time, so windows "
+                f"are processed one after another; this can take several minutes each.\n"
+                f"All windows append into the same vulnerability_remediation table.\n\n"
+                f"Check progress with: "
+                f'check_rapid7_export_status(export_id="{job_id}")'
             )
-            lines.append("All chunks load into the same vulnerability_remediation table.")
-
-            return "\n".join(lines)
 
         elif export_type == "asset_software":
             new_id = create_asset_software_export(config)
@@ -386,16 +397,24 @@ def check_rapid7_export_status(export_id: str) -> str:
     restart. Does NOT poll or wait.
 
     Args:
-        export_id: The export ID returned by start_rapid7_export.
+        export_id: The export ID returned by start_rapid7_export, or a
+            job ID returned by a multi-window remediation load.
 
     Returns:
         Current export/load status and next steps.
     """
     try:
+        # A multi-window remediation load is tracked as a job spanning N export
+        # IDs; if the id names a job, report the job's progress.
+        tracker = _tracker()
+        job = tracker.get_job(export_id)
+        if job is not None:
+            tracker.close()
+            return _format_job_status(job)
+
         # Local load phase takes precedence: if a background download/load is
         # active or has reached a terminal state, report that and skip the
         # (now-redundant) platform-side status call.
-        tracker = _tracker()
         local = tracker.get_export_by_id(export_id)
         tracker.close()
 
@@ -457,6 +476,68 @@ def check_rapid7_export_status(export_id: str) -> str:
         return f"✗ Error checking export status: {str(e)}"
 
 
+def _download_and_load_files(
+    export_type: str,
+    status_info: dict,
+    api_key: str,
+) -> tuple:
+    """Download an export's parquet files and load them into DuckDB.
+
+    Shared by the single-export worker and the multi-chunk remediation
+    orchestrator so the download/route/load path is not forked. Acquires
+    _db_lock around the load. Returns (row_count, row_counts, stats,
+    validation_warnings).
+    """
+    global db
+
+    parquet_urls = status_info["parquetFiles"]
+    file_data = download_all_files(parquet_urls, api_key)
+
+    temp_dir = tempfile.mkdtemp()
+    validation_warnings: list = []
+    try:
+        with _db_lock:
+            if db is None:
+                initialize_database()
+
+            result_list = status_info.get("result") or []
+            url_to_prefix = {}
+            for item in result_list:
+                prefix = item.get("prefix", "")
+                for url in item.get("urls", []):
+                    url_to_prefix[url] = prefix
+
+            prefix_file_map: dict = {}
+            for i, (url, data) in enumerate(zip(parquet_urls, file_data)):
+                temp_path = Path(temp_dir) / f"{export_type}_export_{i}.parquet"
+                temp_path.write_bytes(data)
+                prefix = url_to_prefix.get(url, "unknown")
+                prefix_file_map.setdefault(prefix, []).append(str(temp_path))
+                if len(data) < 100:
+                    validation_warnings.append(f"File {i + 1} (prefix={prefix}): unusually small ({len(data)} bytes)")
+
+            if export_type == "policy":
+                row_counts = db.load_parquet_files_by_prefix(prefix_file_map, skip_prefixes={"asset"})
+            elif export_type == "remediation":
+                row_counts = db.load_parquet_files_by_prefix(prefix_file_map, append=True)
+            else:
+                row_counts = db.load_parquet_files_by_prefix(prefix_file_map)
+
+            row_count = sum(row_counts.values())
+            if row_count == 0 and len(file_data) > 0:
+                validation_warnings.append(
+                    f"⚠️  {len(file_data)} file(s) downloaded but 0 rows loaded. "
+                    f"Prefixes received: {list(prefix_file_map.keys())}. "
+                    f"Check that prefixes match expected routing."
+                )
+
+            stats = db.get_stats()
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    return row_count, row_counts, stats, validation_warnings
+
+
 def _run_download_and_load(export_id: str, export_type: str) -> None:
     """Background worker: download parquet files and load them into DuckDB.
 
@@ -468,8 +549,6 @@ def _run_download_and_load(export_id: str, export_type: str) -> None:
     duplicate response the way the synchronous version could when a client
     had already timed out and cancelled the request.
     """
-    global db
-
     tracker = _tracker()
     try:
         config = load_config()
@@ -482,61 +561,17 @@ def _run_download_and_load(export_id: str, export_type: str) -> None:
             phase_detail=f"0 / {len(parquet_urls)} files downloaded",
         )
         print(f"Downloading {len(parquet_urls)} {export_type} files...", file=sys.stderr)
-        file_data = download_all_files(parquet_urls, config["api_key"])
 
         tracker.set_phase(
             export_id,
             PHASE_LOADING,
-            phase_detail=f"{len(parquet_urls)} / {len(parquet_urls)} files downloaded, loading into database",
+            phase_detail=f"{len(parquet_urls)} files downloaded, loading into database",
         )
 
-        temp_dir = tempfile.mkdtemp()
-        validation_warnings = []
-
-        try:
-            with _db_lock:
-                if db is None:
-                    initialize_database()
-
-                result_list = status_info.get("result") or []
-
-                url_to_prefix = {}
-                for item in result_list:
-                    prefix = item.get("prefix", "")
-                    for url in item.get("urls", []):
-                        url_to_prefix[url] = prefix
-
-                prefix_file_map = {}
-                for i, (url, data) in enumerate(zip(parquet_urls, file_data)):
-                    temp_path = Path(temp_dir) / f"{export_type}_export_{i}.parquet"
-                    temp_path.write_bytes(data)
-                    prefix = url_to_prefix.get(url, "unknown")
-                    prefix_file_map.setdefault(prefix, []).append(str(temp_path))
-                    if len(data) < 100:
-                        validation_warnings.append(
-                            f"File {i + 1} (prefix={prefix}): unusually small ({len(data)} bytes)"
-                        )
-
-                if export_type == "policy":
-                    row_counts = db.load_parquet_files_by_prefix(prefix_file_map, skip_prefixes={"asset"})
-                elif export_type == "remediation":
-                    row_counts = db.load_parquet_files_by_prefix(prefix_file_map, append=True)
-                else:
-                    row_counts = db.load_parquet_files_by_prefix(prefix_file_map)
-
-                row_count = sum(row_counts.values())
-                row_info = f"Rows loaded: {row_count}\nPer-table row counts: {json.dumps(row_counts, default=str)}"
-
-                if row_count == 0 and len(file_data) > 0:
-                    validation_warnings.append(
-                        f"⚠️  {len(file_data)} file(s) downloaded but 0 rows loaded. "
-                        f"Prefixes received: {list(prefix_file_map.keys())}. "
-                        f"Check that prefixes match expected routing."
-                    )
-
-                stats = db.get_stats()
-        finally:
-            shutil.rmtree(temp_dir, ignore_errors=True)
+        row_count, row_counts, stats, validation_warnings = _download_and_load_files(
+            export_type, status_info, config["api_key"]
+        )
+        row_info = f"Rows loaded: {row_count}\nPer-table row counts: {json.dumps(row_counts, default=str)}"
 
         warnings_section = ""
         if validation_warnings:
@@ -575,6 +610,146 @@ def _run_download_and_load(export_id: str, export_type: str) -> None:
         tracker.set_phase(export_id, PHASE_FAILED, phase_detail=None, message=message)
     finally:
         tracker.close()
+
+
+def _create_remediation_chunk_waiting(config: dict, chunk_start: str, chunk_end: str) -> str:
+    """Create one remediation chunk, waiting out any foreign in-flight export.
+
+    The platform permits only one remediation export in flight at a time. If
+    another is running (this job's previous chunk, or an unrelated export),
+    create is rejected with ExportInProgressError. We must NOT adopt that
+    foreign id — it may cover a different date range — so we back off and
+    recreate THIS chunk's own range until the platform frees up.
+    """
+    deadline = time.monotonic() + _IN_PROGRESS_MAX_WAIT_SECS
+    while True:
+        try:
+            return create_remediation_export(config, chunk_start, chunk_end)
+        except ExportInProgressError:
+            if time.monotonic() >= deadline:
+                raise
+            print(
+                f"Remediation export slot busy; waiting to create {chunk_start} → {chunk_end}...",
+                file=sys.stderr,
+            )
+            time.sleep(_IN_PROGRESS_RETRY_SECS)
+
+
+def _run_remediation_job(job_id: str, chunks: list) -> None:
+    """Background worker: load a multi-window remediation range as one job.
+
+    Processes each ≤31-day window strictly sequentially (create → poll →
+    download → load append), because the platform serialises remediation
+    exports anyway. Per-chunk outcome is persisted on the export_jobs row so a
+    partial failure names exactly which windows loaded and which did not.
+    """
+    tracker = _tracker()
+    try:
+        config = load_config()
+        total = len(chunks)
+        total_rows = 0
+
+        for i, chunk in enumerate(chunks):
+            cs, ce = chunk["start"], chunk["end"]
+            window = f"{cs} → {ce}"
+
+            def _mark(state: str) -> None:
+                chunks[i]["status"] = state
+                tracker.update_job(
+                    job_id,
+                    current_index=i,
+                    chunks=chunks,
+                    message=f"chunk {i + 1}/{total} ({window}), {state}",
+                )
+
+            _mark("creating")
+            eid = _create_remediation_chunk_waiting(config, cs, ce)
+            chunks[i]["export_id"] = eid
+
+            _mark("waiting for export")
+            parquet_urls = poll_until_complete(config, eid)
+            status_info = get_export_status(config, eid)
+            if not parquet_urls:
+                status_info["parquetFiles"] = status_info.get("parquetFiles", [])
+
+            _mark("loading")
+            row_count, _, _, _ = _download_and_load_files("remediation", status_info, config["api_key"])
+            total_rows += row_count
+            chunks[i]["row_count"] = row_count
+            tracker.save_export(
+                export_id=eid,
+                status=PHASE_COMPLETE,
+                parquet_urls=parquet_urls,
+                row_count=row_count,
+                export_type="remediation",
+            )
+            _mark("loaded")
+
+        loaded = [f"{c['start']} → {c['end']} ({c.get('row_count', 0)} rows)" for c in chunks]
+        message = (
+            f"✓ Remediation data loaded for all {total} window(s).\n\n"
+            f"Total rows: {total_rows}\n"
+            f"Windows loaded:\n" + "\n".join(f"  {w}" for w in loaded) + "\n\n"
+            "Query the data with query_rapid7, get_rapid7_schema, or get_rapid7_stats."
+        )
+        tracker.update_job(job_id, status=JOB_COMPLETE, current_index=total - 1, chunks=chunks, message=message)
+
+    except Exception as e:
+        error_text = f"{e}\n{traceback.format_exc()}"
+        loaded = [f"{c['start']} → {c['end']}" for c in chunks if c.get("status") == "loaded"]
+        missing = [f"{c['start']} → {c['end']}" for c in chunks if c.get("status") != "loaded"]
+        message = (
+            f"✗ Remediation load failed partway through.\n\n"
+            f"Loaded windows (kept): {', '.join(loaded) or 'none'}\n"
+            f"Missing windows: {', '.join(missing) or 'none'}\n\n"
+            f"Re-run only the missing range with start_rapid7_export("
+            f'export_type="remediation", start_date="...", end_date="...").\n\n'
+            f"{error_text}"
+        )
+        tracker.update_job(job_id, status=JOB_FAILED, chunks=chunks, message=message)
+    finally:
+        tracker.close()
+
+
+def _start_remediation_job(start_date: str, end_date: str) -> str:
+    """Create and launch a multi-window remediation load job. Returns the job_id."""
+    chunk_ranges = build_remediation_date_chunks(start_date, end_date)
+    chunks = [{"start": cs, "end": ce, "export_id": None, "status": "pending"} for cs, ce in chunk_ranges]
+
+    job_id = f"remediation-{uuid.uuid4().hex[:12]}"
+    tracker = _tracker()
+    tracker.create_job(
+        job_id=job_id,
+        export_type="remediation",
+        start_date=start_date,
+        end_date=end_date,
+        chunks=chunks,
+        status=JOB_RUNNING,
+    )
+    tracker.close()
+
+    thread = threading.Thread(target=_run_remediation_job, args=(job_id, chunks), daemon=True)
+    thread.start()
+    return job_id
+
+
+def _format_job_status(job: dict) -> str:
+    """Render an export_jobs row for check_rapid7_export_status."""
+    status = job.get("status")
+    if status == JOB_COMPLETE:
+        return job.get("message") or f"✓ Remediation job {job['job_id']} complete."
+    if status == JOB_FAILED:
+        return job.get("message") or f"✗ Remediation job {job['job_id']} failed."
+
+    total = len(job.get("chunks") or [])
+    return (
+        f"⏳ Remediation load in progress.\n\n"
+        f"Job ID: {job['job_id']}\n"
+        f"Range: {job.get('start_date')} → {job.get('end_date')} ({total} window(s))\n"
+        f"{job.get('message', '')}\n\n"
+        f"Check again in 30-60 seconds with: "
+        f'check_rapid7_export_status(export_id="{job["job_id"]}")'
+    )
 
 
 @mcp.tool(

--- a/tests/test_duckdb_loader.py
+++ b/tests/test_duckdb_loader.py
@@ -452,3 +452,29 @@ def test_VulnerabilityDatabase_VulnLoadPreservesPolicyData(
         assert policy_rows_after == 2, f"Policy rows lost after vulnerability load: expected 2, got {policy_rows_after}"
 
         db.close()
+
+
+def test_append_returns_per_call_inserted_counts(sample_remediation_parquet_file):
+    """Append mode must report rows inserted BY THIS CALL, not the table's
+    cumulative total. Regression for the multi-window remediation sum bug
+    where three 2-row windows reported 2, 4, 6 (total 12) instead of 2, 2, 2."""
+    db = VulnerabilityDatabase()
+    prefix_map = {"vulnerability_remediation": [sample_remediation_parquet_file]}
+
+    first = db.load_parquet_files_by_prefix(prefix_map, append=True)
+    second = db.load_parquet_files_by_prefix(prefix_map, append=True)
+    third = db.load_parquet_files_by_prefix(prefix_map, append=True)
+
+    # Each call inserted the same 2 rows — the returned count is the delta.
+    assert first["vulnerability_remediation"] == 2
+    assert second["vulnerability_remediation"] == 2
+    assert third["vulnerability_remediation"] == 2
+
+    # Summing per-call counts gives the true total (2+2+2=6), not 2+4+6=12.
+    total = (
+        first["vulnerability_remediation"] + second["vulnerability_remediation"] + third["vulnerability_remediation"]
+    )
+    assert total == 6
+    # And the table really does hold 6 rows.
+    assert db.query("SELECT COUNT(*) AS c FROM vulnerability_remediation")[0]["c"] == 6
+    db.close()

--- a/tests/test_export_manager.py
+++ b/tests/test_export_manager.py
@@ -8,7 +8,20 @@ querying status, and polling for completion.
 import pytest
 import responses
 
-from src.export_manager import create_asset_software_export, create_vulnerability_export, get_export_status
+from src.export_manager import (
+    ExportInProgressError,
+    create_asset_software_export,
+    create_remediation_export,
+    create_vulnerability_export,
+    get_export_status,
+)
+
+_ENDPOINT = "https://us.api.insight.rapid7.com/export/graphql"
+
+
+def _in_progress_response(export_id: str = "abc123XYZ=="):
+    """A GraphQL 'already in-progress' error body carrying an in-flight export id."""
+    return {"errors": [{"message": f"Export already in-progress exportId: {export_id}"}]}
 
 
 class TestCreateVulnerabilityExport:
@@ -756,3 +769,33 @@ class TestCreateAssetSoftwareExport:
 
         with pytest.raises(ValueError, match="GraphQL errors.*Unauthorized"):
             create_asset_software_export(config)
+
+
+class TestInProgressHandling:
+    """The platform allows one export per type at a time. Snapshot exports may
+    reuse the in-flight export; remediation must not (it is date-range scoped)."""
+
+    @responses.activate
+    def test_remediation_raises_export_in_progress_with_extracted_id(self):
+        responses.add(responses.POST, _ENDPOINT, json=_in_progress_response("XyZ789plusEQ=="), status=200)
+        config = {"endpoint": _ENDPOINT, "api_key": "k"}
+
+        with pytest.raises(ExportInProgressError) as excinfo:
+            create_remediation_export(config, "2026-01-01", "2026-01-15")
+
+        assert excinfo.value.export_id == "XyZ789plusEQ=="
+
+    @responses.activate
+    def test_vulnerability_snapshot_returns_in_flight_id_unchanged(self):
+        """Regression guard on the deliberate asymmetry: snapshots reuse the id."""
+        responses.add(responses.POST, _ENDPOINT, json=_in_progress_response("snapABC123=="), status=200)
+        config = {"endpoint": _ENDPOINT, "api_key": "k"}
+
+        assert create_vulnerability_export(config) == "snapABC123=="
+
+    @responses.activate
+    def test_asset_software_snapshot_returns_in_flight_id_unchanged(self):
+        responses.add(responses.POST, _ENDPOINT, json=_in_progress_response("assetXYZ456=="), status=200)
+        config = {"endpoint": _ENDPOINT, "api_key": "k"}
+
+        assert create_asset_software_export(config) == "assetXYZ456=="

--- a/tests/test_export_tracker.py
+++ b/tests/test_export_tracker.py
@@ -128,3 +128,49 @@ def test_context_manager(temp_db):
 
     # Connection should be closed after context
     # We can't easily test this without accessing private attributes
+
+
+def test_find_job_by_range(temp_db):
+    """find_job_by_range returns the job matching an exact export_type + range."""
+    tracker = ExportTracker(temp_db)
+    tracker.create_job(
+        job_id="job-a",
+        export_type="remediation",
+        start_date="2026-01-01",
+        end_date="2026-03-01",
+        chunks=[{"start": "2026-01-01", "end": "2026-02-01", "export_id": None, "status": "pending"}],
+        status="RUNNING",
+    )
+    found = tracker.find_job_by_range("remediation", "2026-01-01", "2026-03-01")
+    assert found is not None and found["job_id"] == "job-a"
+    # A different range does not match.
+    assert tracker.find_job_by_range("remediation", "2026-01-01", "2026-02-01") is None
+
+
+def test_reconcile_interrupted_job_names_loaded_and_missing_windows(temp_db):
+    """A RUNNING job reconciled at restart must report per-window state, not a
+    blanket re-run of the whole range (which would duplicate loaded windows)."""
+    tracker = ExportTracker(temp_db)
+    tracker.create_job(
+        job_id="job-interrupted",
+        export_type="remediation",
+        start_date="2026-01-01",
+        end_date="2026-03-04",
+        chunks=[
+            {"start": "2026-01-01", "end": "2026-02-01", "export_id": "e1", "status": "loaded"},
+            {"start": "2026-02-01", "end": "2026-03-04", "export_id": None, "status": "loading"},
+        ],
+        status="RUNNING",
+    )
+
+    tracker.reconcile_interrupted(
+        active_export_statuses=["DOWNLOADING", "LOADING"],
+        active_job_statuses=["RUNNING"],
+        reason="Interrupted by a server restart.",
+    )
+
+    job = tracker.get_job("job-interrupted")
+    assert job["status"] == "FAILED"
+    assert "2026-01-01 → 2026-02-01" in job["message"]  # loaded window named as kept
+    assert "2026-02-01 → 2026-03-04" in job["message"]  # missing window named
+    assert "only the missing" in job["message"]

--- a/tests/test_local_e2e.py
+++ b/tests/test_local_e2e.py
@@ -316,6 +316,53 @@ def test_FullExportRoundTrip_ParallelWithToolCoverage():
             mcp_server.db = orig_db
 
         # ==================================================================
+        # PHASE 3c: Multi-window remediation job (the collapsing-export-ID fix)
+        #
+        # Drive the real start_rapid7_export(remediation) over a >31-day range
+        # so it splits into multiple windows, then poll the single job to
+        # completion. Regression for the bug where multiple windows collapsed
+        # onto one export ID and only one month loaded. Isolated DB.
+        # ==================================================================
+        print("\n" + "=" * 70)
+        print("PHASE 3c: Multi-window remediation job")
+        print("=" * 70)
+
+        rem_dir = Path(tmpdir) / "remediation_job"
+        rem_dir.mkdir()
+        orig_data_dir = mcp_server._DATA_DIR
+        orig_db = mcp_server.db
+        mcp_server._DATA_DIR = rem_dir
+        mcp_server.db = VulnerabilityDatabase(str(rem_dir / "rapid7_bulk_export.db"))
+        try:
+            rem_start = (_dt.date.today() - _dt.timedelta(days=75)).isoformat()
+            rem_end = _dt.date.today().isoformat()
+            expected_windows = len(build_remediation_date_chunks(rem_start, rem_end))
+            assert expected_windows >= 3, f"expected a multi-window range, got {expected_windows}"
+
+            started = mcp_server.start_rapid7_export(export_type="remediation", start_date=rem_start, end_date=rem_end)
+            job_id = next(line.split("Job ID:", 1)[1].strip() for line in started.splitlines() if "Job ID:" in line)
+            print(f"  ✓ started remediation job {job_id} over {expected_windows} windows")
+
+            deadline = time.monotonic() + _MAX_WAIT
+            final = ""
+            while time.monotonic() < deadline:
+                final = mcp_server.check_rapid7_export_status(export_id=job_id)
+                if "loaded for all" in final or "failed partway" in final:
+                    break
+                time.sleep(_POLL_INTERVAL)
+
+            assert "loaded for all" in final, f"remediation job did not complete cleanly: {final}"
+
+            # The job must have created DISTINCT export IDs, one per window.
+            job = ExportTracker(str(rem_dir / "rapid7_bulk_export_tracking.db")).get_job(job_id)
+            eids = [c["export_id"] for c in job["chunks"]]
+            assert len(eids) == len(set(eids)) == expected_windows, f"windows collapsed: {eids}"
+            print(f"  ✓ {expected_windows} distinct window export IDs, no collapse")
+        finally:
+            mcp_server._DATA_DIR = orig_data_dir
+            mcp_server.db = orig_db
+
+        # ==================================================================
         # PHASE 4: Assert cross-export table coexistence (the original bug)
         # ==================================================================
         print("\n" + "=" * 70)

--- a/tests/test_local_e2e.py
+++ b/tests/test_local_e2e.py
@@ -266,6 +266,56 @@ def test_FullExportRoundTrip_ParallelWithToolCoverage():
         print(f"\n  Total remediation rows across {len(remediation_chunks)} chunks: {total_remediation_rows:,}")
 
         # ==================================================================
+        # PHASE 3b: Async download tool round-trip (the timeout-crash fix)
+        #
+        # PHASE 3 loads via the low-level helpers. This phase exercises the
+        # actual MCP tool path — download_rapid7_export() spawning a
+        # background thread and returning immediately, then
+        # check_rapid7_export_status() reporting the local load phase from
+        # the tracker through to COMPLETE — against the live-completed vuln
+        # export, in its own isolated database.
+        # ==================================================================
+        print("\n" + "=" * 70)
+        print("PHASE 3b: Async download tool round-trip")
+        print("=" * 70)
+
+        from src import mcp_server
+
+        async_dir = Path(tmpdir) / "async"
+        async_dir.mkdir()
+        orig_data_dir = mcp_server._DATA_DIR
+        orig_db = mcp_server.db
+        mcp_server._DATA_DIR = async_dir
+        mcp_server.db = VulnerabilityDatabase(str(async_dir / "rapid7_bulk_export.db"))
+        try:
+            start = time.monotonic()
+            started = mcp_server.download_rapid7_export(export_id=vuln_id, export_type="vulnerability")
+            elapsed = time.monotonic() - start
+            assert "Started downloading" in started, started
+            assert elapsed < 5, f"download tool blocked for {elapsed:.1f}s instead of returning immediately"
+            print(f"  ✓ download_rapid7_export returned in {elapsed:.2f}s (non-blocking)")
+
+            # Poll the unified status tool until the local load reaches a terminal state.
+            deadline = time.monotonic() + _MAX_WAIT
+            final = ""
+            while time.monotonic() < deadline:
+                final = mcp_server.check_rapid7_export_status(export_id=vuln_id)
+                if "loaded successfully" in final or "Error downloading/loading" in final:
+                    break
+                assert "in progress locally" in final, f"unexpected status: {final}"
+                time.sleep(_POLL_INTERVAL)
+
+            assert "loaded successfully" in final, f"async load did not complete: {final}"
+            print("  ✓ check_rapid7_export_status reported COMPLETE via tracker phase")
+
+            async_rows = mcp_server.db.query("SELECT COUNT(*) AS cnt FROM vulnerabilities")[0]["cnt"]
+            assert async_rows > 0, "async tool path loaded 0 vulnerability rows"
+            print(f"  ✓ async-loaded vulnerabilities: {async_rows:,} rows")
+        finally:
+            mcp_server._DATA_DIR = orig_data_dir
+            mcp_server.db = orig_db
+
+        # ==================================================================
         # PHASE 4: Assert cross-export table coexistence (the original bug)
         # ==================================================================
         print("\n" + "=" * 70)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -289,3 +289,162 @@ class TestDbLockIsReentrant:
             acquired = mcp_server._db_lock.acquire(blocking=False)
             assert acquired, "_db_lock is not re-entrant"
             mcp_server._db_lock.release()
+
+
+def _patch_remediation(monkeypatch, created_ids, load_side_effect=None, create_side_effect=None):
+    """Wire the remediation orchestrator's platform calls.
+
+    created_ids: appended (start, end) per create so tests can assert distinct
+                 IDs and date order.
+    """
+    monkeypatch.setattr(mcp_server, "load_config", lambda: {"api_key": "k", "endpoint": "https://example.test"})
+
+    def _create(config, start, end):
+        if create_side_effect is not None:
+            create_side_effect(start, end)
+        eid = f"rem-{start}"
+        created_ids.append({"id": eid, "start": start, "end": end})
+        return eid
+
+    monkeypatch.setattr(mcp_server, "create_remediation_export", _create)
+    monkeypatch.setattr(mcp_server, "poll_until_complete", lambda config, eid: ["https://example.test/f.parquet"])
+    monkeypatch.setattr(
+        mcp_server,
+        "get_export_status",
+        lambda config, eid: {
+            "status": "COMPLETE",
+            "parquetFiles": ["https://example.test/f.parquet"],
+            "result": [{"prefix": "remediation", "urls": ["https://example.test/f.parquet"]}],
+        },
+    )
+    monkeypatch.setattr(mcp_server, "download_all_files", lambda urls, api_key: [b"x" * 200 for _ in urls])
+
+
+def _wait_for_job(tmp_path, job_id, target, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        job = _tracker(tmp_path).get_job(job_id)
+        if job is not None and job.get("status") in target:
+            return job
+        time.sleep(0.02)
+    raise AssertionError(f"Job {job_id} did not reach {target} within {timeout}s")
+
+
+def _job_id_from_start(result_text):
+    for line in result_text.splitlines():
+        if line.strip().startswith("Job ID:"):
+            return line.split("Job ID:", 1)[1].strip()
+    raise AssertionError(f"no Job ID in: {result_text}")
+
+
+class TestMultiChunkRemediation:
+    def test_six_month_range_creates_six_distinct_ids_in_date_order(self, monkeypatch, tmp_path):
+        """Direct regression: a >1-month range must create one export per
+        window, each with its OWN id and date range — never collapse to one."""
+        fake_db = FakeDB(row_counts={"vulnerability_remediation": 100})
+        monkeypatch.setattr(mcp_server, "db", fake_db)
+        created = []
+        _patch_remediation(monkeypatch, created)
+
+        result = mcp_server.start_rapid7_export(
+            export_type="remediation", start_date="2026-01-01", end_date="2026-06-30"
+        )
+        job_id = _job_id_from_start(result)
+        job = _wait_for_job(tmp_path, job_id, {mcp_server.JOB_COMPLETE, mcp_server.JOB_FAILED})
+
+        assert job["status"] == mcp_server.JOB_COMPLETE
+        ids = [c["export_id"] for c in job["chunks"]]
+        assert len(ids) == len(set(ids)) == 6, f"expected 6 distinct ids, got {ids}"
+        starts = [c["start"] for c in created]
+        assert starts == sorted(starts), "chunks not created in date order"
+
+    def test_all_windows_append_row_counts_sum(self, monkeypatch, tmp_path):
+        fake_db = FakeDB(row_counts={"vulnerability_remediation": 100})
+        monkeypatch.setattr(mcp_server, "db", fake_db)
+        _patch_remediation(monkeypatch, [])
+
+        result = mcp_server.start_rapid7_export(
+            export_type="remediation", start_date="2026-01-01", end_date="2026-03-15"
+        )
+        job_id = _job_id_from_start(result)
+        job = _wait_for_job(tmp_path, job_id, {mcp_server.JOB_COMPLETE})
+
+        n = len(job["chunks"])
+        assert n == 3
+        # Every chunk appended (load called once per chunk), row total is the sum.
+        assert len(fake_db.load_calls) == n
+        assert sum(c["row_count"] for c in job["chunks"]) == 100 * n
+
+    def test_in_progress_on_a_chunk_retries_same_chunk(self, monkeypatch, tmp_path):
+        """A chunk hitting ExportInProgressError must retry ITS OWN range, not
+        skip or adopt a foreign id."""
+        monkeypatch.setattr(mcp_server, "_IN_PROGRESS_RETRY_SECS", 0.01)
+        fake_db = FakeDB(row_counts={"vulnerability_remediation": 5})
+        monkeypatch.setattr(mcp_server, "db", fake_db)
+
+        state = {"failed_once": set()}
+
+        def _create_side_effect(start, end):
+            # First attempt on the 2nd chunk raises in-progress once, then succeeds.
+            if start not in state["failed_once"] and start == "2026-02-01":
+                state["failed_once"].add(start)
+                raise mcp_server.ExportInProgressError("someone-elses-export==")
+
+        created = []
+        _patch_remediation(monkeypatch, created, create_side_effect=_create_side_effect)
+
+        result = mcp_server.start_rapid7_export(
+            export_type="remediation", start_date="2026-01-01", end_date="2026-02-15"
+        )
+        job_id = _job_id_from_start(result)
+        job = _wait_for_job(tmp_path, job_id, {mcp_server.JOB_COMPLETE})
+
+        ids = [c["export_id"] for c in job["chunks"]]
+        assert "someone-elses-export==" not in ids, "adopted a foreign in-flight id"
+        assert job["chunks"][1]["export_id"] == "rem-2026-02-01", "did not recreate its own chunk"
+
+    def test_partial_failure_names_loaded_and_missing_windows(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(mcp_server, "_IN_PROGRESS_RETRY_SECS", 0.01)
+        fake_db = FakeDB(row_counts={"vulnerability_remediation": 5})
+        monkeypatch.setattr(mcp_server, "db", fake_db)
+        _patch_remediation(monkeypatch, [])
+
+        # Fail the load on the third chunk only.
+        real_loader = mcp_server._download_and_load_files
+        calls = {"n": 0}
+
+        def _flaky(export_type, status_info, api_key):
+            calls["n"] += 1
+            if calls["n"] == 3:
+                raise RuntimeError("simulated load failure on chunk 3")
+            return real_loader(export_type, status_info, api_key)
+
+        monkeypatch.setattr(mcp_server, "_download_and_load_files", _flaky)
+
+        result = mcp_server.start_rapid7_export(
+            export_type="remediation", start_date="2026-01-01", end_date="2026-03-15"
+        )
+        job_id = _job_id_from_start(result)
+        _wait_for_job(tmp_path, job_id, {mcp_server.JOB_FAILED})
+
+        status_text = mcp_server.check_rapid7_export_status(export_id=job_id)
+        assert "failed partway" in status_text
+        assert "2026-01-01" in status_text  # a loaded window is named
+        assert "2026-03-04" in status_text  # the missing window (3rd chunk) is named
+
+    def test_status_tool_reports_job_progress_with_window(self, monkeypatch, tmp_path):
+        """A job id passed to check_rapid7_export_status reports the current window."""
+        tracker = _tracker(tmp_path)
+        tracker.create_job(
+            job_id="remediation-abc",
+            export_type="remediation",
+            start_date="2026-01-01",
+            end_date="2026-03-01",
+            chunks=[{"start": "2026-02-01", "end": "2026-03-01", "export_id": None, "status": "loading"}],
+            status=mcp_server.JOB_RUNNING,
+        )
+        tracker.update_job("remediation-abc", current_index=0, message="chunk 1/1 (2026-02-01 → 2026-03-01), loading")
+
+        result = mcp_server.check_rapid7_export_status(export_id="remediation-abc")
+        assert "in progress" in result
+        assert "2026-02-01 → 2026-03-01" in result

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -546,3 +546,51 @@ class TestReadToolsLockBeforeHasData:
         monkeypatch.setattr(mcp_server, "db", self.ExplodingHasData())
         result = self._held_on_other_thread(mcp_server.get_rapid7_stats)
         assert "background download/load is currently in progress" in result
+
+
+class TestRemediationRangeIdempotency:
+    """A repeated remediation call for the same range must not start a second
+    appending job (addresses the duplicate-append review findings)."""
+
+    def _seed_job(self, tmp_path, status, start="2026-01-01", end="2026-02-01"):
+        tracker = _tracker(tmp_path)
+        tracker.create_job(
+            job_id=f"remediation-seed-{status}",
+            export_type="remediation",
+            start_date=start,
+            end_date=end,
+            chunks=[{"start": start, "end": end, "export_id": "e1", "status": "loaded"}],
+            status=status,
+        )
+        return start, end
+
+    def test_running_job_for_same_range_is_reused(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(mcp_server, "load_config", lambda: {"api_key": "k", "endpoint": "https://x"})
+        start, end = self._seed_job(tmp_path, mcp_server.JOB_RUNNING)
+        result = mcp_server.start_rapid7_export(export_type="remediation", start_date=start, end_date=end)
+        assert "already in progress" in result
+        assert "remediation-seed-RUNNING" in result
+
+    def test_complete_job_for_same_range_returns_stored_result_not_rerun(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(mcp_server, "load_config", lambda: {"api_key": "k", "endpoint": "https://x"})
+        # If the guard failed and it tried to start a job, this would raise.
+        monkeypatch.setattr(
+            mcp_server,
+            "_start_remediation_job",
+            lambda s, e: pytest.fail("must not start a new job for COMPLETE range"),
+        )
+        start, end = self._seed_job(tmp_path, mcp_server.JOB_COMPLETE)
+        result = mcp_server.start_rapid7_export(export_type="remediation", start_date=start, end_date=end)
+        assert "already loaded" in result
+        assert "remediation-seed-COMPLETE" in result
+
+    def test_failed_job_for_same_range_starts_fresh(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(mcp_server, "load_config", lambda: {"api_key": "k", "endpoint": "https://x"})
+        started = {"called": False}
+        monkeypatch.setattr(
+            mcp_server, "_start_remediation_job", lambda s, e: started.update(called=True) or "remediation-new"
+        )
+        start, end = self._seed_job(tmp_path, mcp_server.JOB_FAILED)
+        result = mcp_server.start_rapid7_export(export_type="remediation", start_date=start, end_date=end)
+        assert started["called"], "a FAILED prior job should allow a fresh retry"
+        assert "Started loading remediation" in result

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -448,3 +448,96 @@ class TestMultiChunkRemediation:
         result = mcp_server.check_rapid7_export_status(export_id="remediation-abc")
         assert "in progress" in result
         assert "2026-02-01 → 2026-03-01" in result
+
+
+class TestPurgeRefusesActiveWork:
+    def test_purge_refused_while_a_job_is_running(self, monkeypatch, tmp_path):
+        """C2: purge must refuse while a multi-window job is RUNNING, even
+        though _db_lock is free between windows."""
+        fake_db = FakeDB()
+        monkeypatch.setattr(mcp_server, "db", fake_db)
+        tracker = _tracker(tmp_path)
+        tracker.create_job(
+            job_id="remediation-active",
+            export_type="remediation",
+            start_date="2026-01-01",
+            end_date="2026-02-01",
+            chunks=[{"start": "2026-01-01", "end": "2026-02-01", "export_id": None, "status": "loading"}],
+            status=mcp_server.JOB_RUNNING,
+        )
+
+        result = mcp_server.purge_rapid7_data()
+
+        assert "still active" in result
+        assert fake_db.has_data_value is True, "purge ran despite an active job"
+
+    def test_purge_refused_while_an_export_is_downloading(self, monkeypatch, tmp_path):
+        fake_db = FakeDB()
+        monkeypatch.setattr(mcp_server, "db", fake_db)
+        tracker = _tracker(tmp_path)
+        tracker.save_export(
+            export_id="exp-dl",
+            status=mcp_server.PHASE_DOWNLOADING,
+            parquet_urls=["u1"],
+            export_type="vulnerability",
+        )
+
+        result = mcp_server.purge_rapid7_data()
+
+        assert "still active" in result
+        assert fake_db.has_data_value is True
+
+    def test_purge_succeeds_when_no_active_work(self, monkeypatch, tmp_path):
+        fake_db = FakeDB()
+        monkeypatch.setattr(mcp_server, "db", fake_db)
+
+        result = mcp_server.purge_rapid7_data()
+
+        assert "purged" in result
+        assert fake_db.has_data_value is False
+
+
+class TestReadToolsLockBeforeHasData:
+    """I3: the busy response must win even though has_data() opens its own
+    DuckDB connection — the lock has to be held before has_data() is called.
+    A FakeDB whose has_data() raises stands in for the RO/RW config conflict a
+    real load would trigger; if the tool checked has_data() before locking, the
+    exception would surface instead of the busy message."""
+
+    class ExplodingHasData(FakeDB):
+        def has_data(self):
+            raise RuntimeError("DuckDB config conflict (simulated)")
+
+    def _held_on_other_thread(self, fn):
+        import threading
+
+        holding, release = threading.Event(), threading.Event()
+
+        def holder():
+            with mcp_server._db_lock:
+                holding.set()
+                release.wait(timeout=5)
+
+        t = threading.Thread(target=holder, daemon=True)
+        t.start()
+        holding.wait(timeout=5)
+        try:
+            return fn()
+        finally:
+            release.set()
+            t.join(timeout=5)
+
+    def test_query_busy_before_has_data(self, monkeypatch):
+        monkeypatch.setattr(mcp_server, "db", self.ExplodingHasData())
+        result = self._held_on_other_thread(lambda: mcp_server.query_rapid7(sql="SELECT 1"))
+        assert "background download/load is currently in progress" in result
+
+    def test_schema_busy_before_has_data(self, monkeypatch):
+        monkeypatch.setattr(mcp_server, "db", self.ExplodingHasData())
+        result = self._held_on_other_thread(mcp_server.get_rapid7_schema)
+        assert "background download/load is currently in progress" in result
+
+    def test_stats_busy_before_has_data(self, monkeypatch):
+        monkeypatch.setattr(mcp_server, "db", self.ExplodingHasData())
+        result = self._held_on_other_thread(mcp_server.get_rapid7_stats)
+        assert "background download/load is currently in progress" in result

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,7 +8,10 @@ call after a few minutes and, if the server later tries to respond to that
 already-cancelled request, the whole stdio server process can crash.
 
 download_rapid7_export() now starts the download+load in a background
-thread and returns immediately; check_download_status() polls the result.
+thread and returns immediately. Progress and results are recorded as phase
+transitions on the durable ExportTracker row, and reported by
+check_rapid7_export_status() and list_rapid7_exports() — there is no
+separate status tool.
 """
 
 import time
@@ -16,6 +19,7 @@ import time
 import pytest
 
 from src import mcp_server
+from src.export_tracker import ExportTracker
 
 
 class FakeDB:
@@ -46,17 +50,22 @@ class FakeDB:
     def has_data(self):
         return self.has_data_value
 
+    def purge(self):
+        self.has_data_value = False
+
 
 @pytest.fixture(autouse=True)
 def reset_mcp_server_state(monkeypatch, tmp_path):
-    """Give every test a clean slate: no leftover jobs, no leftover db,
-    and a tracker pointed at a throwaway temp directory."""
-    mcp_server._download_jobs.clear()
+    """Give every test a clean slate: a fresh tracker DB under a throwaway
+    temp dir, and no leftover db handle."""
     monkeypatch.setattr(mcp_server, "db", None)
     monkeypatch.setattr(mcp_server, "_DATA_DIR", tmp_path)
     yield
-    mcp_server._download_jobs.clear()
     monkeypatch.setattr(mcp_server, "db", None)
+
+
+def _tracker(tmp_path):
+    return ExportTracker(str(tmp_path / "rapid7_bulk_export_tracking.db"))
 
 
 def _fake_status_complete(export_id="exp-1", file_count=2):
@@ -78,18 +87,18 @@ def _patch_common(monkeypatch, status=None, file_bytes=b"x" * 200, db=None):
     return status
 
 
-def _wait_for_job_state(export_id, target_states, timeout=5.0):
+def _wait_for_phase(tmp_path, export_id, target_states, timeout=5.0):
     deadline = time.time() + timeout
     while time.time() < deadline:
-        job = mcp_server._get_job(export_id)
-        if job is not None and job.get("state") in target_states:
-            return job
+        row = _tracker(tmp_path).get_export_by_id(export_id)
+        if row is not None and row.get("status") in target_states:
+            return row
         time.sleep(0.02)
-    raise AssertionError(f"Job for {export_id} did not reach {target_states} within {timeout}s")
+    raise AssertionError(f"Export {export_id} did not reach {target_states} within {timeout}s")
 
 
 class TestDownloadRapid7ExportIsNonBlocking:
-    def test_returns_immediately_with_started_message(self, monkeypatch):
+    def test_returns_immediately_with_started_message(self, monkeypatch, tmp_path):
         """The whole point of the fix: this call must not block on the load."""
         fake_db = FakeDB(load_delay=0.3)
         _patch_common(monkeypatch, db=fake_db)
@@ -100,33 +109,34 @@ class TestDownloadRapid7ExportIsNonBlocking:
 
         assert elapsed < 0.5, f"download_rapid7_export blocked for {elapsed}s instead of returning immediately"
         assert "Started downloading and loading" in result
-        assert "check_download_status" in result
+        assert "check_rapid7_export_status" in result
 
         # Drain the background thread so it can't leak into the next test.
-        _wait_for_job_state("exp-immediate", {"complete", "failed"})
+        _wait_for_phase(tmp_path, "exp-immediate", {mcp_server.PHASE_COMPLETE, mcp_server.PHASE_FAILED})
 
-    def test_background_job_eventually_completes(self, monkeypatch):
+    def test_background_job_eventually_completes(self, monkeypatch, tmp_path):
         fake_db = FakeDB(load_delay=0.1, row_counts={"vulnerabilities": 42})
         _patch_common(monkeypatch, db=fake_db)
 
         mcp_server.download_rapid7_export(export_id="exp-completes", export_type="vulnerability")
-        job = _wait_for_job_state("exp-completes", {"complete", "failed"})
+        row = _wait_for_phase(tmp_path, "exp-completes", {mcp_server.PHASE_COMPLETE, mcp_server.PHASE_FAILED})
 
-        assert job["state"] == "complete"
-        status_text = mcp_server.check_download_status(export_id="exp-completes")
+        assert row["status"] == mcp_server.PHASE_COMPLETE
+        assert row["row_count"] == 42
+        status_text = mcp_server.check_rapid7_export_status(export_id="exp-completes")
         assert "loaded successfully" in status_text
         assert "Rows loaded: 42" in status_text
 
-    def test_failed_export_status_returns_synchronously_without_starting_job(self, monkeypatch):
+    def test_failed_export_status_returns_synchronously_without_starting_job(self, monkeypatch, tmp_path):
         """If the export isn't ready yet, there's nothing to background — fail fast."""
         _patch_common(monkeypatch, status={"status": "IN_PROGRESS", "parquetFiles": []})
 
         result = mcp_server.download_rapid7_export(export_id="exp-not-ready", export_type="vulnerability")
 
         assert "not yet complete" in result
-        assert mcp_server._get_job("exp-not-ready") is None
+        assert _tracker(tmp_path).get_export_by_id("exp-not-ready") is None
 
-    def test_duplicate_call_while_job_running_does_not_start_a_second_job(self, monkeypatch):
+    def test_duplicate_call_while_job_running_does_not_start_a_second_job(self, monkeypatch, tmp_path):
         fake_db = FakeDB(load_delay=0.4)
         _patch_common(monkeypatch, db=fake_db)
 
@@ -136,12 +146,12 @@ class TestDownloadRapid7ExportIsNonBlocking:
         second = mcp_server.download_rapid7_export(export_id="exp-duplicate", export_type="vulnerability")
         assert "already in progress" in second
 
-        _wait_for_job_state("exp-duplicate", {"complete", "failed"})
+        _wait_for_phase(tmp_path, "exp-duplicate", {mcp_server.PHASE_COMPLETE, mcp_server.PHASE_FAILED})
         assert len(fake_db.load_calls) == 1, "a second background job was started for the same export"
 
-    def test_background_failure_is_captured_not_raised(self, monkeypatch):
-        """An exception in the background thread must surface through
-        check_download_status, not crash the process."""
+    def test_background_failure_is_captured_not_raised(self, monkeypatch, tmp_path):
+        """An exception in the background thread must surface through the
+        tracker phase, not crash the process."""
 
         class ExplodingDB(FakeDB):
             def load_parquet_files_by_prefix(self, *a, **kw):
@@ -150,41 +160,106 @@ class TestDownloadRapid7ExportIsNonBlocking:
         _patch_common(monkeypatch, db=ExplodingDB())
 
         mcp_server.download_rapid7_export(export_id="exp-fails", export_type="vulnerability")
-        job = _wait_for_job_state("exp-fails", {"complete", "failed"})
+        row = _wait_for_phase(tmp_path, "exp-fails", {mcp_server.PHASE_COMPLETE, mcp_server.PHASE_FAILED})
 
-        assert job["state"] == "failed"
-        status_text = mcp_server.check_download_status(export_id="exp-fails")
+        assert row["status"] == mcp_server.PHASE_FAILED
+        status_text = mcp_server.check_rapid7_export_status(export_id="exp-fails")
         assert "Error downloading/loading" in status_text
-        assert "simulated load failure" in job["error"]
+        assert "simulated load failure" in status_text
 
 
-class TestCheckDownloadStatus:
-    def test_unknown_export_id_returns_helpful_message(self):
-        result = mcp_server.check_download_status(export_id="never-started")
-        assert "No background download job found" in result
+class TestCheckRapid7ExportStatusReportsLocalPhase:
+    def test_unknown_export_id_falls_through_to_platform_status(self, monkeypatch):
+        """No local tracker row -> query the Rapid7 API for platform status."""
+        _patch_common(monkeypatch, status={"status": "PROCESSING", "parquetFiles": []})
 
-    def test_in_progress_shows_file_counts(self, monkeypatch):
-        fake_db = FakeDB(load_delay=0.3)
+        result = mcp_server.check_rapid7_export_status(export_id="never-started")
+        assert "still processing" in result
+
+    def test_in_progress_shows_local_phase_and_progress(self, monkeypatch, tmp_path):
+        fake_db = FakeDB(load_delay=0.4)
         _patch_common(monkeypatch, status=_fake_status_complete(file_count=5), db=fake_db)
 
         mcp_server.download_rapid7_export(export_id="exp-progress", export_type="vulnerability")
-        # Catch it while still downloading/loading, before the background thread finishes.
-        result = mcp_server.check_download_status(export_id="exp-progress")
+        # Catch it before the background thread finishes.
+        result = mcp_server.check_rapid7_export_status(export_id="exp-progress")
 
-        assert "Job is" in result
-        _wait_for_job_state("exp-progress", {"complete", "failed"})
+        assert "in progress locally" in result
+        assert "files downloaded" in result
+        _wait_for_phase(tmp_path, "exp-progress", {mcp_server.PHASE_COMPLETE, mcp_server.PHASE_FAILED})
+
+    def test_active_load_short_circuits_platform_api_call(self, monkeypatch, tmp_path):
+        """While a local load is active, the platform-side API must NOT be
+        called (it's already known complete)."""
+        _tracker(tmp_path).save_export(
+            export_id="exp-active",
+            status=mcp_server.PHASE_LOADING,
+            parquet_urls=["u1"],
+            export_type="vulnerability",
+        )
+
+        def _boom(config, export_id):
+            raise AssertionError("get_export_status must not be called while a local load is active")
+
+        monkeypatch.setattr(mcp_server, "load_config", lambda: {"api_key": "k"})
+        monkeypatch.setattr(mcp_server, "get_export_status", _boom)
+
+        result = mcp_server.check_rapid7_export_status(export_id="exp-active")
+        assert "in progress locally" in result
+
+
+class TestListExportsShowsLivePhase:
+    def test_list_shows_progress_line_for_in_flight_load(self, tmp_path):
+        tracker = _tracker(tmp_path)
+        tracker.save_export(
+            export_id="exp-list",
+            status=mcp_server.PHASE_DOWNLOADING,
+            parquet_urls=["u1", "u2"],
+            export_type="vulnerability",
+        )
+        tracker.set_phase(
+            "exp-list",
+            mcp_server.PHASE_DOWNLOADING,
+            phase_detail="1 / 2 files downloaded",
+        )
+
+        result = mcp_server.list_rapid7_exports(limit=10)
+        assert "exp-list" in result
+        assert "DOWNLOADING" in result
+        assert "Progress: 1 / 2 files downloaded" in result
 
 
 class TestDbLockProtectsReadsDuringLoad:
+    @staticmethod
+    def _run_holding_lock(fn):
+        """Hold _db_lock on a *separate* thread (as a background load does)
+        while running fn on this thread, so the non-blocking acquire in the
+        tool is genuinely contended — an RLock would let the same thread
+        straight through, which is not the real scenario."""
+        import threading
+
+        holding = threading.Event()
+        release = threading.Event()
+
+        def holder():
+            with mcp_server._db_lock:
+                holding.set()
+                release.wait(timeout=5)
+
+        t = threading.Thread(target=holder, daemon=True)
+        t.start()
+        holding.wait(timeout=5)
+        try:
+            return fn()
+        finally:
+            release.set()
+            t.join(timeout=5)
+
     def test_query_returns_busy_message_when_lock_held(self, monkeypatch):
         fake_db = FakeDB()
         monkeypatch.setattr(mcp_server, "db", fake_db)
 
-        mcp_server._db_lock.acquire()
-        try:
-            result = mcp_server.query_rapid7(sql="SELECT 1")
-        finally:
-            mcp_server._db_lock.release()
+        result = self._run_holding_lock(lambda: mcp_server.query_rapid7(sql="SELECT 1"))
 
         assert "background download/load is currently in progress" in result
 
@@ -195,3 +270,22 @@ class TestDbLockProtectsReadsDuringLoad:
         result = mcp_server.query_rapid7(sql="SELECT 1")
 
         assert "Query executed successfully" in result
+
+    def test_purge_returns_busy_message_when_lock_held(self, monkeypatch):
+        """Finding #1: purge must not run while a background load holds the DB."""
+        fake_db = FakeDB()
+        monkeypatch.setattr(mcp_server, "db", fake_db)
+
+        result = self._run_holding_lock(mcp_server.purge_rapid7_data)
+
+        assert "can't be purged right now" in result
+
+
+class TestDbLockIsReentrant:
+    def test_db_lock_can_be_acquired_twice_by_same_thread(self):
+        """Finding #2: RLock prevents self-deadlock if one locked helper
+        calls another that also locks."""
+        with mcp_server._db_lock:
+            acquired = mcp_server._db_lock.acquire(blocking=False)
+            assert acquired, "_db_lock is not re-entrant"
+            mcp_server._db_lock.release()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,197 @@
+"""
+Unit tests for the async download/load job behavior in mcp_server.py.
+
+These tests cover the fix for a real-world failure mode: loading a large
+export (potentially millions of rows) can take longer than an MCP client's
+tool-call timeout. Some clients (e.g. Claude Desktop) hard-cancel a tool
+call after a few minutes and, if the server later tries to respond to that
+already-cancelled request, the whole stdio server process can crash.
+
+download_rapid7_export() now starts the download+load in a background
+thread and returns immediately; check_download_status() polls the result.
+"""
+
+import time
+
+import pytest
+
+from src import mcp_server
+
+
+class FakeDB:
+    """Minimal stand-in for VulnerabilityDatabase, with a hook to
+    simulate a slow load so tests can exercise in-progress states."""
+
+    def __init__(self, load_delay: float = 0.0, row_counts=None, has_data_value: bool = True):
+        self.load_delay = load_delay
+        self.row_counts = row_counts if row_counts is not None else {"vulnerabilities": 3, "assets": 2}
+        self.has_data_value = has_data_value
+        self.load_calls = []
+
+    def load_parquet_files_by_prefix(self, prefix_file_map, skip_prefixes=None, append=False):
+        if self.load_delay:
+            time.sleep(self.load_delay)
+        self.load_calls.append(dict(prefix_file_map))
+        return dict(self.row_counts)
+
+    def get_stats(self):
+        return {"vulnerabilities": {"total_rows": self.row_counts.get("vulnerabilities", 0)}}
+
+    def get_schema(self):
+        return {"vulnerabilities": {"columns": ["assetId", "vulnId"]}}
+
+    def query(self, sql):
+        return [{"ok": 1}]
+
+    def has_data(self):
+        return self.has_data_value
+
+
+@pytest.fixture(autouse=True)
+def reset_mcp_server_state(monkeypatch, tmp_path):
+    """Give every test a clean slate: no leftover jobs, no leftover db,
+    and a tracker pointed at a throwaway temp directory."""
+    mcp_server._download_jobs.clear()
+    monkeypatch.setattr(mcp_server, "db", None)
+    monkeypatch.setattr(mcp_server, "_DATA_DIR", tmp_path)
+    yield
+    mcp_server._download_jobs.clear()
+    monkeypatch.setattr(mcp_server, "db", None)
+
+
+def _fake_status_complete(export_id="exp-1", file_count=2):
+    urls = [f"https://example.test/file{i}.parquet" for i in range(file_count)]
+    return {
+        "status": "COMPLETE",
+        "parquetFiles": urls,
+        "result": [{"prefix": "asset_vulnerability", "urls": urls}],
+    }
+
+
+def _patch_common(monkeypatch, status=None, file_bytes=b"x" * 200, db=None):
+    status = status or _fake_status_complete()
+    monkeypatch.setattr(mcp_server, "load_config", lambda: {"api_key": "test-key", "endpoint": "https://example.test"})
+    monkeypatch.setattr(mcp_server, "get_export_status", lambda config, export_id: status)
+    monkeypatch.setattr(mcp_server, "download_all_files", lambda urls, api_key: [file_bytes for _ in urls])
+    if db is not None:
+        monkeypatch.setattr(mcp_server, "db", db)
+    return status
+
+
+def _wait_for_job_state(export_id, target_states, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        job = mcp_server._get_job(export_id)
+        if job is not None and job.get("state") in target_states:
+            return job
+        time.sleep(0.02)
+    raise AssertionError(f"Job for {export_id} did not reach {target_states} within {timeout}s")
+
+
+class TestDownloadRapid7ExportIsNonBlocking:
+    def test_returns_immediately_with_started_message(self, monkeypatch):
+        """The whole point of the fix: this call must not block on the load."""
+        fake_db = FakeDB(load_delay=0.3)
+        _patch_common(monkeypatch, db=fake_db)
+
+        start = time.time()
+        result = mcp_server.download_rapid7_export(export_id="exp-immediate", export_type="vulnerability")
+        elapsed = time.time() - start
+
+        assert elapsed < 0.5, f"download_rapid7_export blocked for {elapsed}s instead of returning immediately"
+        assert "Started downloading and loading" in result
+        assert "check_download_status" in result
+
+        # Drain the background thread so it can't leak into the next test.
+        _wait_for_job_state("exp-immediate", {"complete", "failed"})
+
+    def test_background_job_eventually_completes(self, monkeypatch):
+        fake_db = FakeDB(load_delay=0.1, row_counts={"vulnerabilities": 42})
+        _patch_common(monkeypatch, db=fake_db)
+
+        mcp_server.download_rapid7_export(export_id="exp-completes", export_type="vulnerability")
+        job = _wait_for_job_state("exp-completes", {"complete", "failed"})
+
+        assert job["state"] == "complete"
+        status_text = mcp_server.check_download_status(export_id="exp-completes")
+        assert "loaded successfully" in status_text
+        assert "Rows loaded: 42" in status_text
+
+    def test_failed_export_status_returns_synchronously_without_starting_job(self, monkeypatch):
+        """If the export isn't ready yet, there's nothing to background — fail fast."""
+        _patch_common(monkeypatch, status={"status": "IN_PROGRESS", "parquetFiles": []})
+
+        result = mcp_server.download_rapid7_export(export_id="exp-not-ready", export_type="vulnerability")
+
+        assert "not yet complete" in result
+        assert mcp_server._get_job("exp-not-ready") is None
+
+    def test_duplicate_call_while_job_running_does_not_start_a_second_job(self, monkeypatch):
+        fake_db = FakeDB(load_delay=0.4)
+        _patch_common(monkeypatch, db=fake_db)
+
+        first = mcp_server.download_rapid7_export(export_id="exp-duplicate", export_type="vulnerability")
+        assert "Started downloading" in first
+
+        second = mcp_server.download_rapid7_export(export_id="exp-duplicate", export_type="vulnerability")
+        assert "already in progress" in second
+
+        _wait_for_job_state("exp-duplicate", {"complete", "failed"})
+        assert len(fake_db.load_calls) == 1, "a second background job was started for the same export"
+
+    def test_background_failure_is_captured_not_raised(self, monkeypatch):
+        """An exception in the background thread must surface through
+        check_download_status, not crash the process."""
+
+        class ExplodingDB(FakeDB):
+            def load_parquet_files_by_prefix(self, *a, **kw):
+                raise RuntimeError("simulated load failure")
+
+        _patch_common(monkeypatch, db=ExplodingDB())
+
+        mcp_server.download_rapid7_export(export_id="exp-fails", export_type="vulnerability")
+        job = _wait_for_job_state("exp-fails", {"complete", "failed"})
+
+        assert job["state"] == "failed"
+        status_text = mcp_server.check_download_status(export_id="exp-fails")
+        assert "Error downloading/loading" in status_text
+        assert "simulated load failure" in job["error"]
+
+
+class TestCheckDownloadStatus:
+    def test_unknown_export_id_returns_helpful_message(self):
+        result = mcp_server.check_download_status(export_id="never-started")
+        assert "No background download job found" in result
+
+    def test_in_progress_shows_file_counts(self, monkeypatch):
+        fake_db = FakeDB(load_delay=0.3)
+        _patch_common(monkeypatch, status=_fake_status_complete(file_count=5), db=fake_db)
+
+        mcp_server.download_rapid7_export(export_id="exp-progress", export_type="vulnerability")
+        # Catch it while still downloading/loading, before the background thread finishes.
+        result = mcp_server.check_download_status(export_id="exp-progress")
+
+        assert "Job is" in result
+        _wait_for_job_state("exp-progress", {"complete", "failed"})
+
+
+class TestDbLockProtectsReadsDuringLoad:
+    def test_query_returns_busy_message_when_lock_held(self, monkeypatch):
+        fake_db = FakeDB()
+        monkeypatch.setattr(mcp_server, "db", fake_db)
+
+        mcp_server._db_lock.acquire()
+        try:
+            result = mcp_server.query_rapid7(sql="SELECT 1")
+        finally:
+            mcp_server._db_lock.release()
+
+        assert "background download/load is currently in progress" in result
+
+    def test_query_works_normally_when_lock_free(self, monkeypatch):
+        fake_db = FakeDB()
+        monkeypatch.setattr(mcp_server, "db", fake_db)
+
+        result = mcp_server.query_rapid7(sql="SELECT 1")
+
+        assert "Query executed successfully" in result

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -99,15 +99,18 @@ def _wait_for_phase(tmp_path, export_id, target_states, timeout=5.0):
 
 class TestDownloadRapid7ExportIsNonBlocking:
     def test_returns_immediately_with_started_message(self, monkeypatch, tmp_path):
-        """The whole point of the fix: this call must not block on the load."""
-        fake_db = FakeDB(load_delay=0.3)
+        """The whole point of the fix: this call must not block on the load.
+        The fake load takes 2s; a non-blocking call returns well under that
+        even under CI load, so a 1s threshold cleanly separates the two
+        without flaking on runner jitter."""
+        fake_db = FakeDB(load_delay=2.0)
         _patch_common(monkeypatch, db=fake_db)
 
         start = time.time()
         result = mcp_server.download_rapid7_export(export_id="exp-immediate", export_type="vulnerability")
         elapsed = time.time() - start
 
-        assert elapsed < 0.5, f"download_rapid7_export blocked for {elapsed}s instead of returning immediately"
+        assert elapsed < 1.0, f"download_rapid7_export blocked for {elapsed}s instead of returning immediately"
         assert "Started downloading and loading" in result
         assert "check_rapid7_export_status" in result
 

--- a/uv.lock
+++ b/uv.lock
@@ -1331,7 +1331,7 @@ wheels = [
 
 [[package]]
 name = "rapid7-vulnerability-export"
-version = "0.5.3"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

Builds on the async-download work from #39 and adds two things on top:

1. **Unified background-load status** — instead of a separate status tool, the
   background download/load phases (`DOWNLOADING → LOADING → COMPLETE/FAILED`)
   are persisted on the durable `ExportTracker` row and reported through the
   existing `check_rapid7_export_status` and `list_rapid7_exports`. Job state now
   survives a server restart; the in-memory job dict is gone.

2. **Multi-window remediation loads every window** — requesting a remediation
   range longer than 31 days previously loaded only a single 31-day window.

## Credit

The async background-download foundation is @tylambert's work from #39 — his
original commit is included here as the base of this branch. This PR builds the
follow-on status unification and the multi-window remediation fix on top.

> This branch is intended to supersede #39 rather than compete with it. Happy to
> close #39 in favor of this once reviewed, whichever the team prefers.

## The remediation bug

The platform allows only one remediation export in flight at a time and splits a
range longer than 31 days into multiple exports. The old flow fired a create for
every window back-to-back; the platform rejected all but the first with an
"already in-progress" error, and `create_remediation_export` returned that
in-flight export's ID as if it were the new window's. Every window collapsed onto
one export ID, so only a single 31-day window was ever downloaded — and which
window was non-deterministic if an unrelated remediation export was already
running.

## What changed

- `create_remediation_export` raises a typed `ExportInProgressError` instead of
  returning a foreign in-flight ID. Snapshot exports (vulnerability, policy,
  asset_software) still reuse an in-flight export — correct for unparameterised
  snapshots, so the asymmetry is deliberate and covered by a regression test.
- `start_rapid7_export(export_type="remediation", …)` starts a single background
  job that processes each ≤31-day window strictly sequentially
  (create → poll → download → load with `append=True`) and accumulates them into
  one `vulnerability_remediation` table. It returns a job ID; poll it with
  `check_rapid7_export_status`. On an in-flight conflict it waits and recreates
  its own window rather than adopting a foreign ID.
- New `export_jobs` table groups the N per-window export IDs under one durable
  job. Partial failure is explicit — the job names which windows loaded and which
  are missing so the missing range can be re-run.
- Extracted a shared `_download_and_load_files` helper so the single-export
  worker and the remediation job don't fork the load path.
- Read-tool DB guard hardened: `_db_lock` is re-entrant, `purge_rapid7_data`
  acquires it, and the tracker's read methods open read-write to avoid a DuckDB
  read-only/read-write config conflict during a concurrent load.
- Docs: README, AGENTS.md, and the agent skill now cover all four export types
  (including asset software and vulnerability exceptions), the six DuckDB tables,
  the non-blocking background download+poll flow, and the remediation job flow.
- Version 0.5.3 → 0.6.0. Added a CHANGELOG.

## Testing

- Unit: 110 passed, 1 skipped (the live E2E). New tests include the direct
  regression — a >1-month range creates distinct export IDs per window with no
  collapse — plus in-progress-retry, partial-failure reporting, and append
  accumulation.
- `ruff` + `ruff format --check` + `bandit`: clean.
- `make local-test` (live, against the real API): PASSED. Added two live phases —
  the async single-export tool round-trip, and a multi-window remediation job
  that verifies distinct export IDs per window and no collapse.

## Upgrade note

Anyone who ran a remediation export covering more than 31 days on an earlier
version may have loaded only part of their range. Re-run that export on 0.6.0 to
get the complete data.
