### PR TITLE
[PLEX-5829] Group this component under the bulk-export Cortex domain

### DIFF
--- a/cortex.yaml
+++ b/cortex.yaml
@@ -9,7 +9,7 @@ info:
   x-cortex-tag: rapid7-bulk-export-mcp
   x-cortex-type: service
   x-cortex-domain-parents:
-    - tag: surface-command-platform
+    - tag: bulk-export
   x-cortex-groups:
     - target:not-deployed
     - strategy:cloud


### PR DESCRIPTION
## Description

Cortex had no handle on Bulk Export as a thing. This component was filed under `surface-command-platform`, which is not where the Bulk Export components live, so the eight repositories that make up the export flow could only be found one at a time — there was no entity to hang ownership, on-call, or a scorecard off.

The [`bulk-export` domain](https://github.com/rapid7/pd-cortex-gitops/blob/main/.cortex/domains/bulk-export.yml) now exists, owned by `rapid7-ragnarok`. This one does change trees: the component leaves `surface-command-platform` and joins the Bulk Export group under `platform-exposure-reporting`.

Blast radius is Cortex's own catalogue graph — no build, deploy, or runtime behaviour reads this file.

## Implementation

One line: `info.x-cortex-domain-parents[0].tag` becomes `bulk-export`. Companion PRs make the same change in the other seven Bulk Export repositories.

The `x-cortex-owners` half of PLEX-5829 is deliberately out of scope here — the domain entity already carries `rapid7-ragnarok`, so team ownership wants a separate decision about whether each component repeats it.

## Testing

None. YAML with no schema in this repo; Cortex validates the tag on ingest, and an unresolvable tag would show as a missing domain parent on the component page.

https://rapid7.atlassian.net/browse/PLEX-5829